### PR TITLE
Specify Baklava-compatible NDK version

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 android {
     namespace = "com.example.rouneboundmagic"
     compileSdkPreview = "Baklava"
+    ndkVersion = "27.1.12297006"
 
     defaultConfig {
         applicationId = "com.example.rouneboundmagic"


### PR DESCRIPTION
## Summary
- set the module to use Android NDK 27.1.12297006 so it supports the Baklava preview SDK

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6ded258008328a34c7bd7b9398c22