### PR TITLE
Target Android 15 SDK

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,12 +5,13 @@ plugins {
 
 android {
     namespace = "com.example.rouneboundmagic"
-    compileSdkPreview = "Baklava"
+    compileSdk = 35
+    ndkVersion = "27.2.12479014"
 
     defaultConfig {
         applicationId = "com.example.rouneboundmagic"
-        minSdkPreview = "Baklava"
-        targetSdkPreview = "Baklava"
+        minSdk = 24
+        targetSdk = 35
         versionCode = 1
         versionName = "1.0"
 


### PR DESCRIPTION
## Summary
- update the module to compile and target the stable Android 15 (API 35) SDK
- set the minimum SDK level to API 24 for wider device compatibility

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6ded258008328a34c7bd7b9398c22