### PR TITLE
Lower core-ktx dependency to maintain compileSdk 35

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "8.12.3"
 kotlin = "2.0.21"
-coreKtx = "1.17.0"
+coreKtx = "1.16.0"
 junit = "4.13.2"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"


### PR DESCRIPTION
## Summary
- downgrade androidx.core:core-ktx to 1.16.0 so it no longer requires compileSdk 36
- keep the project compiling against API level 35 as requested

## Testing
- ./gradlew assembleDebug *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6e309a76c8328bf9352ef37ae7b94