### PR TITLE
Center board background with margins

### DIFF
--- a/app/src/main/cpp/Renderer.h
+++ b/app/src/main/cpp/Renderer.h
@@ -7,6 +7,8 @@
 #include "Model.h"
 #include "Shader.h"
 
+class TextureAsset;
+
 struct android_app;
 
 class Renderer {
@@ -69,6 +71,8 @@ private:
 
     std::unique_ptr<Shader> shader_;
     std::vector<Model> models_;
+    std::shared_ptr<TextureAsset> spBoardTexture_;
+    std::shared_ptr<TextureAsset> spGemTexture_;
 };
 
 #endif //ANDROIDGLINVESTIGATIONS_RENDERER_H


### PR DESCRIPTION
## Summary
- scale the board background uniformly with margins and center it within the viewport
- reuse cached textures and rebuild models whenever the viewport size changes to maintain alignment

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6ec03d6088328ab90db80f059feab