### PR TITLE
Implement match-3 board with characters

### DIFF
--- a/app/src/main/cpp/Renderer.h
+++ b/app/src/main/cpp/Renderer.h
@@ -3,6 +3,7 @@
 
 #include <EGL/egl.h>
 #include <memory>
+#include <random>
 
 #include "Model.h"
 #include "Shader.h"
@@ -23,7 +24,11 @@ public:
             context_(EGL_NO_CONTEXT),
             width_(0),
             height_(0),
-            shaderNeedsNewProjectionMatrix_(true) {
+            shaderNeedsNewProjectionMatrix_(true),
+            rng_(std::random_device{}()),
+            gemDistribution_(0, 2),
+            sceneDirty_(true),
+            boardReady_(false) {
         initRenderer();
     }
 
@@ -60,6 +65,29 @@ private:
      */
     void createModels();
 
+    enum class GemType {
+        None = -1,
+        Red = 0,
+        Green = 1,
+        Blue = 2,
+    };
+
+    void ensureBoardInitialized();
+    GemType randomGem();
+    GemType getGem(int row, int col) const;
+    void setGem(int row, int col, GemType type);
+    std::vector<std::pair<int, int>> findMatches() const;
+    void removeMatches(const std::vector<std::pair<int, int>> &matches);
+    void applyGravityAndFill();
+    bool updateBoardState();
+    Model buildQuadModel(float left,
+                         float top,
+                         float right,
+                         float bottom,
+                         float z,
+                         const std::shared_ptr<TextureAsset> &texture) const;
+    std::shared_ptr<TextureAsset> textureForGem(GemType type) const;
+
     android_app *app_;
     EGLDisplay display_;
     EGLSurface surface_;
@@ -72,7 +100,17 @@ private:
     std::unique_ptr<Shader> shader_;
     std::vector<Model> models_;
     std::shared_ptr<TextureAsset> spBoardTexture_;
-    std::shared_ptr<TextureAsset> spGemTexture_;
+    std::shared_ptr<TextureAsset> spRedGemTexture_;
+    std::shared_ptr<TextureAsset> spGreenGemTexture_;
+    std::shared_ptr<TextureAsset> spBlueGemTexture_;
+    std::shared_ptr<TextureAsset> spHeroTexture_;
+    std::shared_ptr<TextureAsset> spEnemyTexture_;
+
+    std::vector<GemType> board_;
+    std::mt19937 rng_;
+    std::uniform_int_distribution<int> gemDistribution_;
+    bool sceneDirty_;
+    bool boardReady_;
 };
 
 #endif //ANDROIDGLINVESTIGATIONS_RENDERER_H


### PR DESCRIPTION
## Summary
- render the puzzle board centered on screen using the provided board texture
- populate the board with randomly chosen red, green, and blue gems that respond to match-3 clears, gravity, and respawns
- display hero and enemy portraits beside the board while keeping scene geometry in sync with viewport changes

## Testing
- ./gradlew assembleDebug *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6fe73e5448328b0ffbf1ce2812783