### PR TITLE
Implement match-3 combat overlays

### DIFF
--- a/app/src/main/cpp/Renderer.h
+++ b/app/src/main/cpp/Renderer.h
@@ -4,6 +4,8 @@
 #include <EGL/egl.h>
 #include <memory>
 #include <random>
+#include <utility>
+#include <vector>
 
 #include "Model.h"
 #include "Shader.h"
@@ -28,7 +30,11 @@ public:
             rng_(std::random_device{}()),
             gemDistribution_(0, 2),
             sceneDirty_(true),
-            boardReady_(false) {
+            boardReady_(false),
+            heroHP_(heroMaxHP_),
+            enemyHP_(enemyMaxHP_),
+            heroMana_(0),
+            battleOutcome_(BattleOutcome::None) {
         initRenderer();
     }
 
@@ -72,13 +78,25 @@ private:
         Blue = 2,
     };
 
+    struct MatchGroup {
+        GemType type;
+        std::vector<std::pair<int, int>> cells;
+    };
+
+    enum class BattleOutcome {
+        None,
+        Victory,
+        Defeat,
+    };
+
     void ensureBoardInitialized();
     GemType randomGem();
     GemType getGem(int row, int col) const;
     void setGem(int row, int col, GemType type);
-    std::vector<std::pair<int, int>> findMatches() const;
-    void removeMatches(const std::vector<std::pair<int, int>> &matches);
+    std::vector<MatchGroup> findMatches() const;
+    void removeMatches(const std::vector<MatchGroup> &matches);
     void applyGravityAndFill();
+    void applyMatchEffects(const std::vector<MatchGroup> &matches);
     bool updateBoardState();
     Model buildQuadModel(float left,
                          float top,
@@ -105,12 +123,25 @@ private:
     std::shared_ptr<TextureAsset> spBlueGemTexture_;
     std::shared_ptr<TextureAsset> spHeroTexture_;
     std::shared_ptr<TextureAsset> spEnemyTexture_;
+    std::shared_ptr<TextureAsset> spHPBackgroundTexture_;
+    std::shared_ptr<TextureAsset> spHeroHPTexture_;
+    std::shared_ptr<TextureAsset> spEnemyHPTexture_;
+    std::shared_ptr<TextureAsset> spManaTexture_;
+    std::shared_ptr<TextureAsset> spVictoryTexture_;
+    std::shared_ptr<TextureAsset> spDefeatTexture_;
 
     std::vector<GemType> board_;
     std::mt19937 rng_;
     std::uniform_int_distribution<int> gemDistribution_;
     bool sceneDirty_;
     bool boardReady_;
+    int heroHP_;
+    int enemyHP_;
+    int heroMana_;
+    const int heroMaxHP_ = 100;
+    const int enemyMaxHP_ = 100;
+    const int heroMaxMana_ = 100;
+    BattleOutcome battleOutcome_;
 };
 
 #endif //ANDROIDGLINVESTIGATIONS_RENDERER_H

--- a/app/src/main/cpp/TextureAsset.cpp
+++ b/app/src/main/cpp/TextureAsset.cpp
@@ -1,6 +1,10 @@
 #include "TextureAsset.h"
 #include "AndroidOut.h"
 #include "Utility.h"
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <unordered_map>
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb_image.h"
 
@@ -106,6 +110,100 @@ std::shared_ptr<TextureAsset> TextureAsset::createSolidColorTexture(
             pixel);
 
     return std::shared_ptr<TextureAsset>(new TextureAsset(textureId, 1, 1));
+}
+
+std::shared_ptr<TextureAsset> TextureAsset::createTextTexture(
+        const std::string &text,
+        uint8_t red,
+        uint8_t green,
+        uint8_t blue,
+        uint8_t alpha) {
+    if (text.empty()) {
+        return createSolidColorTexture(0, 0, 0, 0);
+    }
+
+    static const int glyphWidth = 5;
+    static const int glyphHeight = 7;
+    static const int glyphSpacing = 1;
+    static const int pixelScale = 6;
+
+    struct Glyph {
+        std::array<uint8_t, glyphHeight> rows;
+    };
+
+    static const std::unordered_map<char, Glyph> glyphs = {
+            {'A', {{0b01110, 0b10001, 0b10001, 0b11111, 0b10001, 0b10001, 0b10001}}},
+            {'C', {{0b01110, 0b10001, 0b10000, 0b10000, 0b10000, 0b10001, 0b01110}}},
+            {'D', {{0b11110, 0b10001, 0b10001, 0b10001, 0b10001, 0b10001, 0b11110}}},
+            {'E', {{0b11111, 0b10000, 0b10000, 0b11110, 0b10000, 0b10000, 0b11111}}},
+            {'F', {{0b11111, 0b10000, 0b10000, 0b11110, 0b10000, 0b10000, 0b10000}}},
+            {'I', {{0b11111, 0b00100, 0b00100, 0b00100, 0b00100, 0b00100, 0b11111}}},
+            {'O', {{0b01110, 0b10001, 0b10001, 0b10001, 0b10001, 0b10001, 0b01110}}},
+            {'R', {{0b11110, 0b10001, 0b10001, 0b11110, 0b10100, 0b10010, 0b10001}}},
+            {'T', {{0b11111, 0b00100, 0b00100, 0b00100, 0b00100, 0b00100, 0b00100}}},
+            {'V', {{0b10001, 0b10001, 0b10001, 0b10001, 0b10001, 0b01010, 0b00100}}},
+            {'Y', {{0b10001, 0b10001, 0b01010, 0b00100, 0b00100, 0b00100, 0b00100}}},
+            {' ', {{0b00000, 0b00000, 0b00000, 0b00000, 0b00000, 0b00000, 0b00000}}}
+    };
+
+    const int normalizedWidth = static_cast<int>(text.size()) * (glyphWidth + glyphSpacing) - glyphSpacing;
+    const int textureWidth = std::max(normalizedWidth, glyphWidth) * pixelScale;
+    const int textureHeight = glyphHeight * pixelScale;
+
+    std::vector<uint8_t> pixels(textureWidth * textureHeight * 4, 0);
+
+    int cursorX = 0;
+    for (char ch: text) {
+        char upper = static_cast<char>(std::toupper(static_cast<unsigned char>(ch)));
+        auto glyphIt = glyphs.find(upper);
+        Glyph glyph = glyphIt != glyphs.end() ? glyphIt->second : glyphs.at(' ');
+
+        for (int row = 0; row < glyphHeight; ++row) {
+            for (int col = 0; col < glyphWidth; ++col) {
+                bool filled = (glyph.rows[row] >> (glyphWidth - 1 - col)) & 0x1;
+                if (!filled) {
+                    continue;
+                }
+                for (int y = 0; y < pixelScale; ++y) {
+                    for (int x = 0; x < pixelScale; ++x) {
+                        int targetX = (cursorX + col) * pixelScale + x;
+                        int targetY = row * pixelScale + y;
+                        if (targetX < 0 || targetX >= textureWidth || targetY < 0 || targetY >= textureHeight) {
+                            continue;
+                        }
+                        size_t idx = static_cast<size_t>(targetY * textureWidth + targetX) * 4;
+                        pixels[idx + 0] = red;
+                        pixels[idx + 1] = green;
+                        pixels[idx + 2] = blue;
+                        pixels[idx + 3] = alpha;
+                    }
+                }
+            }
+        }
+
+        cursorX += glyphWidth + glyphSpacing;
+    }
+
+    GLuint textureId = 0;
+    glGenTextures(1, &textureId);
+    glBindTexture(GL_TEXTURE_2D, textureId);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+
+    glTexImage2D(
+            GL_TEXTURE_2D,
+            0,
+            GL_RGBA,
+            textureWidth,
+            textureHeight,
+            0,
+            GL_RGBA,
+            GL_UNSIGNED_BYTE,
+            pixels.data());
+
+    return std::shared_ptr<TextureAsset>(new TextureAsset(textureId, textureWidth, textureHeight));
 }
 
 TextureAsset::~TextureAsset() {

--- a/app/src/main/cpp/TextureAsset.h
+++ b/app/src/main/cpp/TextureAsset.h
@@ -30,6 +30,17 @@ public:
             uint8_t blue,
             uint8_t alpha = 255);
 
+    /*!
+     * Δημιουργεί μια υφή με απλό μονόχρωμο κείμενο βασισμένο σε πλέγμα 5x7.
+     * Χρήσιμο για ελαφριά overlays χωρίς εξωτερικά assets.
+     */
+    static std::shared_ptr<TextureAsset> createTextTexture(
+            const std::string &text,
+            uint8_t red,
+            uint8_t green,
+            uint8_t blue,
+            uint8_t alpha = 255);
+
     ~TextureAsset();
 
     /*!


### PR DESCRIPTION
## Summary
- render hero and enemy portraits with health and mana bars beside the puzzle board
- add match grouping logic that drives HP damage, healing, mana gain, and battle resolution banners
- provide a lightweight text texture generator for Victory/Defeat overlays

## Testing
- ./gradlew assembleDebug *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d7391443d48328885df5646a34b515