### PR TITLE
Implement gem combat effects and swapping interactions

### DIFF
--- a/app/src/main/cpp/Renderer.h
+++ b/app/src/main/cpp/Renderer.h
@@ -2,6 +2,8 @@
 #define ANDROIDGLINVESTIGATIONS_RENDERER_H
 
 #include <EGL/egl.h>
+#include <array>
+#include <cstdint>
 #include <memory>
 #include <random>
 #include <utility>
@@ -98,6 +100,12 @@ private:
     void applyGravityAndFill();
     void applyMatchEffects(const std::vector<MatchGroup> &matches);
     bool updateBoardState();
+    bool processMatches();
+    bool attemptSwap(int startRow, int startCol, int endRow, int endCol);
+    bool screenToWorld(float screenX, float screenY, float &worldX, float &worldY) const;
+    bool worldToBoardCell(float worldX, float worldY, int &outRow, int &outCol) const;
+    void handlePointerDown(int32_t pointerId, float screenX, float screenY);
+    void handlePointerUp(int32_t pointerId, float screenX, float screenY);
     Model buildQuadModel(float left,
                          float top,
                          float right,
@@ -142,6 +150,21 @@ private:
     const int enemyMaxHP_ = 100;
     const int heroMaxMana_ = 100;
     BattleOutcome battleOutcome_;
+    bool boardGeometryValid_ = false;
+    float boardLeft_ = 0.0f;
+    float boardRight_ = 0.0f;
+    float boardTop_ = 0.0f;
+    float boardBottom_ = 0.0f;
+    float gridLeft_ = 0.0f;
+    float gridTop_ = 0.0f;
+    float gridRight_ = 0.0f;
+    float gridBottom_ = 0.0f;
+    float cellWidth_ = 0.0f;
+    float cellHeight_ = 0.0f;
+    bool hasSelectedCell_ = false;
+    int selectedRow_ = 0;
+    int selectedCol_ = 0;
+    int32_t activePointerId_ = -1;
 };
 
 #endif //ANDROIDGLINVESTIGATIONS_RENDERER_H


### PR DESCRIPTION
## Summary
- load hero and enemy textures with position-aware rendering and persistent board geometry
- update match resolution to apply per-gem combat and mana effects with cascading gravity
- add touch input to select adjacent gems, swap them, and resolve resulting matches while keeping board stable

## Testing
- ./gradlew assembleDebug (fails: SDK location not found)

------
https://chatgpt.com/codex/tasks/task_e_68d73f42dec08328b57cda4e04d2132f