### PR TITLE
Render characters and HP bars beside the board

### DIFF
--- a/app/src/main/cpp/Renderer.h
+++ b/app/src/main/cpp/Renderer.h
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <memory>
 #include <random>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -113,6 +114,31 @@ private:
                          float bottom,
                          float z,
                          const std::shared_ptr<TextureAsset> &texture) const;
+    void renderTexture(const std::shared_ptr<TextureAsset> &texture,
+                       float left,
+                       float bottom,
+                       float width,
+                       float height,
+                       float z = 0.05f);
+    void renderQuad(float left,
+                    float bottom,
+                    float width,
+                    float height,
+                    float r,
+                    float g,
+                    float b,
+                    float a,
+                    float z);
+    void drawHPBar(int hp,
+                   int hpMax,
+                   float left,
+                   float bottom,
+                   float width,
+                   float height);
+    std::shared_ptr<TextureAsset> getSolidColorTexture(float r,
+                                                       float g,
+                                                       float b,
+                                                       float a);
     std::shared_ptr<TextureAsset> textureForGem(GemType type) const;
 
     android_app *app_;
@@ -132,12 +158,10 @@ private:
     std::shared_ptr<TextureAsset> spBlueGemTexture_;
     std::shared_ptr<TextureAsset> spHeroTexture_;
     std::shared_ptr<TextureAsset> spEnemyTexture_;
-    std::shared_ptr<TextureAsset> spHPBackgroundTexture_;
-    std::shared_ptr<TextureAsset> spHeroHPTexture_;
-    std::shared_ptr<TextureAsset> spEnemyHPTexture_;
-    std::shared_ptr<TextureAsset> spManaTexture_;
+    std::shared_ptr<TextureAsset> spWhiteTexture_;
     std::shared_ptr<TextureAsset> spVictoryTexture_;
     std::shared_ptr<TextureAsset> spDefeatTexture_;
+    std::unordered_map<uint32_t, std::shared_ptr<TextureAsset>> solidColorTextures_;
 
     std::vector<GemType> board_;
     std::mt19937 rng_;


### PR DESCRIPTION
## Summary
- load the hero, enemy, and white textures and compute explicit world positions for the character portraits and HP bars next to the board
- add reusable helpers for drawing textures and colored quads so HP bars scale with the current health values

## Testing
- ./gradlew assembleDebug *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d751fcc32083289f599f01ee4b6f0f