### PR TITLE
Implement fullscreen intro playback

### DIFF
--- a/app/src/main/java/com/example/rouneboundmagic/IntroActivity.kt
+++ b/app/src/main/java/com/example/rouneboundmagic/IntroActivity.kt
@@ -1,16 +1,12 @@
 package com.example.rouneboundmagic
 
 import android.content.Intent
-import android.media.MediaPlayer
 import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import android.widget.Button
 import android.widget.VideoView
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.view.WindowCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.WindowInsetsControllerCompat
 
 class IntroActivity : AppCompatActivity() {
 
@@ -20,8 +16,9 @@ class IntroActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        hideSystemBars()
-
+        window.decorView.systemUiVisibility =
+            View.SYSTEM_UI_FLAG_FULLSCREEN or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+        supportActionBar?.hide()
 
         setContentView(R.layout.activity_intro)
 
@@ -32,7 +29,6 @@ class IntroActivity : AppCompatActivity() {
         videoView.setVideoURI(videoUri)
         videoView.setOnPreparedListener { mediaPlayer ->
             mediaPlayer.isLooping = false
-            mediaPlayer.setVideoScalingMode(MediaPlayer.VIDEO_SCALING_MODE_SCALE_TO_FIT_WITH_CROPPING)
             videoView.start()
         }
 
@@ -45,22 +41,4 @@ class IntroActivity : AppCompatActivity() {
             finish()
         }
     }
-
-
-    private fun hideSystemBars() {
-        WindowCompat.setDecorFitsSystemWindows(window, false)
-        val controller = WindowInsetsControllerCompat(window, window.decorView)
-        controller.hide(WindowInsetsCompat.Type.statusBars() or WindowInsetsCompat.Type.navigationBars())
-        controller.systemBarsBehavior =
-            WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-        supportActionBar?.hide()
-    }
-
-    override fun onWindowFocusChanged(hasFocus: Boolean) {
-        super.onWindowFocusChanged(hasFocus)
-        if (hasFocus) {
-            hideSystemBars()
-        }
-    }
-
 }


### PR DESCRIPTION
## Summary
- ensure IntroActivity hides system UI for fullscreen playback
- play intro video to completion before revealing start button
- keep simple transition to MainActivity after the intro finishes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d782b4ade483289fa2c65c030c1761