### PR TITLE
Improve intro video fullscreen experience

### DIFF
--- a/app/src/main/java/com/example/rouneboundmagic/IntroActivity.kt
+++ b/app/src/main/java/com/example/rouneboundmagic/IntroActivity.kt
@@ -3,27 +3,28 @@ package com.example.rouneboundmagic
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
-import android.view.View
 import android.widget.Button
 import android.widget.VideoView
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 
 class IntroActivity : AppCompatActivity() {
 
     private lateinit var videoView: VideoView
-    private lateinit var startGameButton: Button
+    private lateinit var startButton: Button
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        window.decorView.systemUiVisibility =
-            View.SYSTEM_UI_FLAG_FULLSCREEN or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-        supportActionBar?.hide()
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        hideSystemBars()
 
         setContentView(R.layout.activity_intro)
 
-        videoView = findViewById(R.id.introVideoView)
-        startGameButton = findViewById(R.id.startGameButton)
+        videoView = findViewById(R.id.introVideo)
+        startButton = findViewById(R.id.startButton)
 
         val videoUri = Uri.parse("android.resource://$packageName/${R.raw.intro}")
         videoView.setVideoURI(videoUri)
@@ -31,14 +32,27 @@ class IntroActivity : AppCompatActivity() {
             mediaPlayer.isLooping = false
             videoView.start()
         }
-
         videoView.setOnCompletionListener {
-            startGameButton.visibility = View.VISIBLE
+            startButton.visibility = android.view.View.VISIBLE
         }
 
-        startGameButton.setOnClickListener {
+        startButton.setOnClickListener {
             startActivity(Intent(this, MainActivity::class.java))
             finish()
         }
+    }
+
+    override fun onWindowFocusChanged(hasFocus: Boolean) {
+        super.onWindowFocusChanged(hasFocus)
+        if (hasFocus) {
+            hideSystemBars()
+        }
+    }
+
+    private fun hideSystemBars() {
+        val controller = WindowInsetsControllerCompat(window, window.decorView)
+        controller.hide(WindowInsetsCompat.Type.systemBars())
+        controller.systemBarsBehavior =
+            WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
     }
 }

--- a/app/src/main/res/layout/activity_intro.xml
+++ b/app/src/main/res/layout/activity_intro.xml
@@ -5,18 +5,20 @@
     android:background="@android:color/black">
 
     <VideoView
-        android:id="@+id/introVideoView"
+        android:id="@+id/introVideo"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:keepScreenOn="true"
-        android:scaleType="fitXY" />
+        android:layout_gravity="center"
+        android:keepScreenOn="true" />
 
     <Button
-        android:id="@+id/startGameButton"
+        android:id="@+id/startButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
+        android:backgroundTint="@android:color/holo_purple"
         android:text="@string/start_game"
+        android:textColor="@android:color/white"
         android:visibility="gone" />
 
 </FrameLayout>


### PR DESCRIPTION
## Summary
- ensure the intro layout uses a fullscreen VideoView with a centered start button style
- update IntroActivity to hide system bars with WindowInsetsControllerCompat and show the start button after playback

## Testing
- `./gradlew :app:assembleDebug` *(fails: Android SDK not configured in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7a56861448328bdb2f2ea76b92864