### PR TITLE
Add rune selection video overlay effect

### DIFF
--- a/app/src/main/cpp/Renderer.h
+++ b/app/src/main/cpp/Renderer.h
@@ -117,9 +117,12 @@ private:
     bool processMatches();
     bool attemptSwap(int startRow, int startCol, int endRow, int endCol);
     bool screenToWorld(float screenX, float screenY, float &worldX, float &worldY) const;
+    bool worldToScreen(float worldX, float worldY, float &screenX, float &screenY) const;
     bool worldToBoardCell(float worldX, float worldY, int &outRow, int &outCol) const;
     void handlePointerDown(int32_t pointerId, float screenX, float screenY);
     void handlePointerUp(int32_t pointerId, float screenX, float screenY);
+    void triggerRuneSelectionEffect(int row, int col);
+    void sendRuneSelectionToJava(float centerX, float centerY, float sizePx);
     Model buildQuadModel(float left,
                          float top,
                          float right,


### PR DESCRIPTION
## Summary
- add a Kotlin VideoView overlay that plays the circle.mp4 effect whenever a rune is selected
- convert rune coordinates to screen space inside the native renderer and notify the activity through JNI so the overlay can be positioned correctly

## Testing
- `./gradlew assembleDebug` *(fails: Android SDK path not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d843b7ae0c8328a6b247252678a2a2