### PR TITLE
Add image-based rune selection overlay

### DIFF
--- a/app/src/main/cpp/Renderer.h
+++ b/app/src/main/cpp/Renderer.h
@@ -123,6 +123,7 @@ private:
     void handlePointerUp(int32_t pointerId, float screenX, float screenY);
     void triggerRuneSelectionEffect(int row, int col);
     void sendRuneSelectionToJava(float centerX, float centerY, float sizePx);
+    void sendRuneDeselectionToJava();
     Model buildQuadModel(float left,
                          float top,
                          float right,


### PR DESCRIPTION
## Summary
- replace the VideoView selection effect with an ImageView that renders assets/puzzle/circle.png
- animate the rune selection highlight to fade in/out while tracking rune position and size
- notify the activity from native code when a rune is deselected so the overlay hides correctly

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d849131f008328aa79b0adf85fac01