### PR TITLE
Add air rune and intro enhancements

### DIFF
--- a/app/src/main/cpp/Renderer.h
+++ b/app/src/main/cpp/Renderer.h
@@ -32,13 +32,12 @@ public:
             height_(0),
             shaderNeedsNewProjectionMatrix_(true),
             rng_(std::random_device{}()),
-            gemDistribution_(0, 2),
-            skullChanceDistribution_(0.0f, 1.0f),
+            gemDistribution_(0, 3),
             sceneDirty_(true),
             boardReady_(false),
             heroHP_(heroMaxHP_),
             enemyHP_(enemyMaxHP_),
-            heroMana_(0),
+            heroShield_(0),
             gameState_(GameState::START) {
         initRenderer();
     }
@@ -78,10 +77,10 @@ private:
 
     enum class GemType {
         None = -1,
-        Red = 0,
-        Green = 1,
-        Blue = 2,
-        Skull = 3,
+        Fire = 0,
+        Water = 1,
+        Air = 2,
+        Earth = 3,
     };
 
     struct MatchGroup {
@@ -113,6 +112,7 @@ private:
     void removeMatches(const std::vector<MatchGroup> &matches);
     void applyGravityAndFill();
     void applyMatchEffects(const std::vector<MatchGroup> &matches);
+    void spawnWindEffect(const std::vector<std::pair<int, int>> &cells);
     bool updateBoardState();
     bool processMatches();
     bool attemptSwap(int startRow, int startCol, int endRow, int endCol);
@@ -160,6 +160,7 @@ private:
     void updateRuneTarget(int row, int col, Rune &rune);
     void updateAllRuneTargets(bool snapToTarget);
     void updateRuneAnimation(float deltaTimeSeconds);
+    void updateWindEffects(float deltaTimeSeconds);
     std::pair<float, float> cellCenter(int row, int col) const;
 
     android_app *app_;
@@ -177,7 +178,8 @@ private:
     std::shared_ptr<TextureAsset> spRedGemTexture_;
     std::shared_ptr<TextureAsset> spGreenGemTexture_;
     std::shared_ptr<TextureAsset> spBlueGemTexture_;
-    std::shared_ptr<TextureAsset> spSkullGemTexture_;
+    std::shared_ptr<TextureAsset> spTurquoiseGemTexture_;
+    std::shared_ptr<TextureAsset> spWindSwirlTexture_;
     std::shared_ptr<TextureAsset> spHeroTexture_;
     std::shared_ptr<TextureAsset> spEnemyTexture_;
     std::shared_ptr<TextureAsset> spWhiteTexture_;
@@ -188,15 +190,14 @@ private:
     std::vector<Rune> board_;
     std::mt19937 rng_;
     std::uniform_int_distribution<int> gemDistribution_;
-    std::uniform_real_distribution<float> skullChanceDistribution_;
     bool sceneDirty_;
     bool boardReady_;
     int heroHP_;
     int enemyHP_;
-    int heroMana_;
+    int heroShield_;
     const int heroMaxHP_ = 100;
     const int enemyMaxHP_ = 100;
-    const int heroMaxMana_ = 100;
+    const int heroMaxShield_ = 100;
     GameState gameState_;
     bool boardGeometryValid_ = false;
     float boardLeft_ = 0.0f;
@@ -215,6 +216,19 @@ private:
     int selectedCol_ = 0;
     int32_t activePointerId_ = -1;
     std::chrono::steady_clock::time_point lastFrameTime_ = std::chrono::steady_clock::now();
+    struct WindSwirl {
+        float centerX;
+        float centerY;
+        float radius;
+        float angularVelocity;
+        float angle;
+        float life;
+        float maxLife;
+        float baseSize;
+        float pulseFrequency;
+        float radiusGrowth;
+    };
+    std::vector<WindSwirl> windSwirls_;
 };
 
 #endif //ANDROIDGLINVESTIGATIONS_RENDERER_H

--- a/app/src/main/java/com/example/rouneboundmagic/IntroActivity.kt
+++ b/app/src/main/java/com/example/rouneboundmagic/IntroActivity.kt
@@ -30,6 +30,7 @@ class IntroActivity : AppCompatActivity() {
     private lateinit var gemRow: LinearLayout
     private lateinit var redGem: ImageView
     private lateinit var blueGem: ImageView
+    private lateinit var turquoiseGem: ImageView
     private lateinit var greenGem: ImageView
     private lateinit var subtitleText: TextView
     private lateinit var startButton: Button
@@ -55,6 +56,7 @@ class IntroActivity : AppCompatActivity() {
         gemRow = findViewById(R.id.gemRow)
         redGem = findViewById(R.id.redGem)
         blueGem = findViewById(R.id.blueGem)
+        turquoiseGem = findViewById(R.id.turquoiseGem)
         greenGem = findViewById(R.id.greenGem)
         subtitleText = findViewById(R.id.subtitleText)
         startButton = findViewById(R.id.startButton)
@@ -105,6 +107,7 @@ class IntroActivity : AppCompatActivity() {
         loadBitmap("puzzle/red_gem.png")?.let(redGem::setImageBitmap)
         loadBitmap("puzzle/blue_gem.png")?.let(blueGem::setImageBitmap)
         loadBitmap("puzzle/green_gem.png")?.let(greenGem::setImageBitmap)
+        loadBitmap("puzzle/turquoise.png")?.let(turquoiseGem::setImageBitmap)
         loadBitmap("puzzle/black_wizard.png")?.let(blackWizard::setImageBitmap)
         loadBitmap("puzzle/elf.png")?.let(elfGuardian::setImageBitmap)
     }
@@ -134,22 +137,25 @@ class IntroActivity : AppCompatActivity() {
     }
 
     private fun playSceneOne() {
-        showSubtitle("The world was once bound by the elemental runes — Fire, Water, and Earth — that kept the balance of magic alive.")
+        showSubtitle("The world was once bound by the elemental runes — Fire, Water, Air, and Earth — that kept the balance of magic alive.")
         prepareGemsForScene()
         playAudio(R.raw.a1) {
             startScene(1)
         }
         handler.postDelayed({ revealGem(redGem) }, 3000L)
         handler.postDelayed({ revealGem(blueGem) }, 4000L)
-        handler.postDelayed({ revealGem(greenGem) }, 5000L)
+        handler.postDelayed({ revealGem(turquoiseGem) }, 5000L)
+        handler.postDelayed({ revealGem(greenGem) }, 6000L)
     }
 
     private fun playSceneTwo() {
         stopGlow(redGem)
         stopGlow(blueGem)
+        stopGlow(turquoiseGem)
         stopGlow(greenGem)
         fadeOutView(redGem)
         fadeOutView(blueGem)
+        fadeOutView(turquoiseGem)
         fadeOutView(greenGem)
 
         showSubtitle("But balance is a chain meant to be broken… and I, the Black Wizard, will forge a new world from the ashes.")
@@ -173,7 +179,7 @@ class IntroActivity : AppCompatActivity() {
     private fun playSceneFour() {
         val offset = resources.displayMetrics.widthPixels * 0.28f
 
-        showSubtitle("The battle of runes begins. Match their power, wield their magic, and decide the fate of the realm.")
+        showSubtitle("The battle of Fire, Water, Air, and Earth has begun!")
 
         showFinalCharacter(blackWizard, wizardAura, offset)
         showFinalCharacter(elfGuardian, elfAura, -offset)
@@ -181,6 +187,7 @@ class IntroActivity : AppCompatActivity() {
         prepareGemsForScene()
         revealGem(redGem)
         revealGem(blueGem)
+        revealGem(turquoiseGem)
         revealGem(greenGem)
 
         playAudio(R.raw.a4) {
@@ -192,7 +199,7 @@ class IntroActivity : AppCompatActivity() {
 
     private fun prepareGemsForScene() {
         gemRow.visibility = View.VISIBLE
-        listOf(redGem, blueGem, greenGem).forEach { gem ->
+        listOf(redGem, blueGem, turquoiseGem, greenGem).forEach { gem ->
             gem.visibility = View.VISIBLE
             gem.alpha = 0f
             gem.scaleX = 1f

--- a/app/src/main/res/layout/activity_intro.xml
+++ b/app/src/main/res/layout/activity_intro.xml
@@ -70,6 +70,13 @@
             android:padding="8dp" />
 
         <ImageView
+            android:id="@+id/turquoiseGem"
+            android:layout_width="96dp"
+            android:layout_height="96dp"
+            android:alpha="0"
+            android:padding="8dp" />
+
+        <ImageView
             android:id="@+id/greenGem"
             android:layout_width="96dp"
             android:layout_height="96dp"


### PR DESCRIPTION
## Summary
- update the intro sequence to showcase the four elemental runes with the new air rune assets and messaging
- extend the renderer to support four elemental runes, wind spell visuals, and an earth shield bar
- replace the video-based selection overlay with an animated circle highlight and refresh the victory banner text

## Testing
- ./gradlew lint *(fails: SDK location not found in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68daa562a3a8832895ef7de54b647643