### PR TITLE
Add character selection flow and intro card layout

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,12 @@
         android:theme="@style/Theme.RouneboundMagic">
         <activity
             android:name=".IntroActivity"
+            android:exported="false" />
+        <activity
+            android:name=".CharacterSelectionActivity"
+            android:exported="false" />
+        <activity
+            android:name=".StartGameActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/example/rouneboundmagic/CharacterSelectionActivity.kt
+++ b/app/src/main/java/com/example/rouneboundmagic/CharacterSelectionActivity.kt
@@ -1,0 +1,75 @@
+package com.example.rouneboundmagic
+
+import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.os.Bundle
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.WindowCompat
+
+class CharacterSelectionActivity : AppCompatActivity() {
+
+    private val heroBitmaps = mutableMapOf<String, Bitmap>()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        setContentView(R.layout.activity_character_selection)
+
+        setupHeroCard(
+            imageId = R.id.warriorCard,
+            labelId = R.id.warriorLabel,
+            hero = HeroOption.WARRIOR
+        )
+        setupHeroCard(
+            imageId = R.id.mageCard,
+            labelId = R.id.mageLabel,
+            hero = HeroOption.MAGE
+        )
+        setupHeroCard(
+            imageId = R.id.priestessCard,
+            labelId = R.id.priestessLabel,
+            hero = HeroOption.MYSTICAL_PRIESTESS
+        )
+        setupHeroCard(
+            imageId = R.id.rangerCard,
+            labelId = R.id.rangerLabel,
+            hero = HeroOption.RANGER
+        )
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        heroBitmaps.values.forEach(Bitmap::recycle)
+        heroBitmaps.clear()
+    }
+
+    private fun setupHeroCard(imageId: Int, labelId: Int, hero: HeroOption) {
+        val imageView: ImageView = findViewById(imageId)
+        val labelView: TextView = findViewById(labelId)
+
+        labelView.text = getString(hero.displayNameRes)
+        imageView.setImageBitmap(loadBitmap(hero.assetPath))
+        imageView.setOnClickListener { onHeroSelected(hero) }
+    }
+
+    private fun onHeroSelected(hero: HeroOption) {
+        val intent = Intent(this, IntroActivity::class.java)
+        intent.putExtra(IntroActivity.EXTRA_SELECTED_HERO, hero.name)
+        startActivity(intent)
+    }
+
+    private fun loadBitmap(path: String): Bitmap? {
+        return heroBitmaps[path] ?: run {
+            val bitmap = runCatching {
+                assets.open(path).use(BitmapFactory::decodeStream)
+            }.getOrNull()
+            if (bitmap != null) {
+                heroBitmaps[path] = bitmap
+            }
+            bitmap
+        }
+    }
+}

--- a/app/src/main/java/com/example/rouneboundmagic/HeroOption.kt
+++ b/app/src/main/java/com/example/rouneboundmagic/HeroOption.kt
@@ -1,0 +1,36 @@
+package com.example.rouneboundmagic
+
+import androidx.annotation.StringRes
+
+enum class HeroOption(
+    @StringRes val displayNameRes: Int,
+    val assetPath: String,
+    @StringRes val descriptionRes: Int
+) {
+    WARRIOR(
+        displayNameRes = R.string.hero_warrior,
+        assetPath = "characters/warrior.png",
+        descriptionRes = R.string.hero_warrior_desc
+    ),
+    MAGE(
+        displayNameRes = R.string.hero_mage,
+        assetPath = "characters/mage.png",
+        descriptionRes = R.string.hero_mage_desc
+    ),
+    MYSTICAL_PRIESTESS(
+        displayNameRes = R.string.hero_priestess,
+        assetPath = "characters/mystical_priestess.png",
+        descriptionRes = R.string.hero_priestess_desc
+    ),
+    RANGER(
+        displayNameRes = R.string.hero_ranger,
+        assetPath = "characters/ranger.png",
+        descriptionRes = R.string.hero_ranger_desc
+    );
+
+    companion object {
+        fun fromName(name: String?): HeroOption {
+            return values().firstOrNull { it.name == name } ?: MYSTICAL_PRIESTESS
+        }
+    }
+}

--- a/app/src/main/java/com/example/rouneboundmagic/IntroActivity.kt
+++ b/app/src/main/java/com/example/rouneboundmagic/IntroActivity.kt
@@ -1,340 +1,79 @@
 package com.example.rouneboundmagic
 
-import android.animation.ValueAnimator
 import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.drawable.BitmapDrawable
-import android.media.MediaPlayer
 import android.os.Bundle
-import android.os.Handler
-import android.os.Looper
-import android.view.View
 import android.widget.Button
 import android.widget.ImageView
-import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.WindowCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.WindowInsetsControllerCompat
-import java.io.IOException
 
 class IntroActivity : AppCompatActivity() {
 
-    private lateinit var backgroundImage: ImageView
-    private lateinit var wizardAura: ImageView
-    private lateinit var elfAura: ImageView
-    private lateinit var blackWizard: ImageView
-    private lateinit var elfGuardian: ImageView
-    private lateinit var gemRow: LinearLayout
-    private lateinit var redGem: ImageView
-    private lateinit var blueGem: ImageView
-    private lateinit var turquoiseGem: ImageView
-    private lateinit var greenGem: ImageView
-    private lateinit var subtitleText: TextView
-    private lateinit var startButton: Button
+    private lateinit var heroCardView: ImageView
+    private lateinit var heroNameView: TextView
+    private lateinit var heroDescriptionView: TextView
+    private lateinit var villainCardView: ImageView
+    private lateinit var continueButton: Button
+    private lateinit var selectedHero: HeroOption
 
-    private val handler = Handler(Looper.getMainLooper())
-    private var mediaPlayer: MediaPlayer? = null
-    private val assetBitmaps = mutableMapOf<String, Bitmap>()
-    private val glowAnimators = mutableMapOf<View, ValueAnimator>()
+    private var heroBitmap: Bitmap? = null
+    private var villainBitmap: Bitmap? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
         WindowCompat.setDecorFitsSystemWindows(window, false)
-        hideSystemBars()
-
         setContentView(R.layout.activity_intro)
 
-        backgroundImage = findViewById(R.id.backgroundImage)
-        wizardAura = findViewById(R.id.wizardAura)
-        elfAura = findViewById(R.id.elfAura)
-        blackWizard = findViewById(R.id.blackWizard)
-        elfGuardian = findViewById(R.id.elfGuardian)
-        gemRow = findViewById(R.id.gemRow)
-        redGem = findViewById(R.id.redGem)
-        blueGem = findViewById(R.id.blueGem)
-        turquoiseGem = findViewById(R.id.turquoiseGem)
-        greenGem = findViewById(R.id.greenGem)
-        subtitleText = findViewById(R.id.subtitleText)
-        startButton = findViewById(R.id.startButton)
+        heroCardView = findViewById(R.id.heroCard)
+        heroNameView = findViewById(R.id.heroName)
+        heroDescriptionView = findViewById(R.id.heroDescription)
+        villainCardView = findViewById(R.id.villainCard)
+        continueButton = findViewById(R.id.continueButton)
 
-        loadBackground()
-        loadCharacterAssets()
+        selectedHero = HeroOption.fromName(intent.getStringExtra(EXTRA_SELECTED_HERO))
+        bindHero(selectedHero)
+        bindVillain()
 
-        startButton.setOnClickListener {
-            startActivity(Intent(this, MainActivity::class.java))
+        continueButton.setOnClickListener {
+            val intent = Intent(this, MainActivity::class.java)
+            intent.putExtra(MainActivity.EXTRA_SELECTED_HERO, selectedHero.name)
+            startActivity(intent)
             finish()
-        }
-
-        startScene(0)
-    }
-
-    override fun onWindowFocusChanged(hasFocus: Boolean) {
-        super.onWindowFocusChanged(hasFocus)
-        if (hasFocus) {
-            hideSystemBars()
         }
     }
 
     override fun onDestroy() {
         super.onDestroy()
-        handler.removeCallbacksAndMessages(null)
-        mediaPlayer?.release()
-        mediaPlayer = null
-        glowAnimators.values.forEach(ValueAnimator::cancel)
-        glowAnimators.clear()
-        assetBitmaps.values.forEach(Bitmap::recycle)
-        assetBitmaps.clear()
+        heroBitmap?.recycle()
+        heroBitmap = null
+        villainBitmap?.recycle()
+        villainBitmap = null
     }
 
-    private fun hideSystemBars() {
-        val controller = WindowInsetsControllerCompat(window, window.decorView)
-        controller.hide(WindowInsetsCompat.Type.systemBars())
-        controller.systemBarsBehavior =
-            WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+    private fun bindHero(hero: HeroOption) {
+        heroNameView.text = getString(hero.displayNameRes)
+        heroDescriptionView.text = getString(hero.descriptionRes)
+        heroBitmap = loadBitmap(hero.assetPath)
+        heroBitmap?.let { heroCardView.setImageDrawable(BitmapDrawable(resources, it)) }
     }
 
-    private fun loadBackground() {
-        loadBitmap("intro/MysticalTempleRuins")?.let { bitmap ->
-            backgroundImage.setImageDrawable(BitmapDrawable(resources, bitmap))
-        }
-    }
-
-    private fun loadCharacterAssets() {
-        loadBitmap("puzzle/red_gem.png")?.let(redGem::setImageBitmap)
-        loadBitmap("puzzle/blue_gem.png")?.let(blueGem::setImageBitmap)
-        loadBitmap("puzzle/green_gem.png")?.let(greenGem::setImageBitmap)
-        loadBitmap("puzzle/turquoise.png")?.let(turquoiseGem::setImageBitmap)
-        loadBitmap("puzzle/black_wizard.png")?.let(blackWizard::setImageBitmap)
-        loadBitmap("puzzle/elf.png")?.let(elfGuardian::setImageBitmap)
+    private fun bindVillain() {
+        villainBitmap = loadBitmap(VILLAIN_ASSET_PATH)
+        villainBitmap?.let { villainCardView.setImageDrawable(BitmapDrawable(resources, it)) }
     }
 
     private fun loadBitmap(path: String): Bitmap? {
-        return assetBitmaps[path] ?: run {
-            val bitmap = try {
-                assets.open(path).use(BitmapFactory::decodeStream)
-            } catch (io: IOException) {
-                null
-            }
-            if (bitmap != null) {
-                assetBitmaps[path] = bitmap
-            }
-            bitmap
-        }
+        return runCatching {
+            assets.open(path).use(BitmapFactory::decodeStream)
+        }.getOrNull()
     }
 
-    private fun startScene(index: Int) {
-        handler.removeCallbacksAndMessages(null)
-        when (index) {
-            0 -> playSceneOne()
-            1 -> playSceneTwo()
-            2 -> playSceneThree()
-            3 -> playSceneFour()
-        }
-    }
-
-    private fun playSceneOne() {
-        showSubtitle("The world was once bound by the elemental runes — Fire, Water, Air, and Earth — that kept the balance of magic alive.")
-        prepareGemsForScene()
-        playAudio(R.raw.a1) {
-            startScene(1)
-        }
-        handler.postDelayed({ revealGem(redGem) }, 3000L)
-        handler.postDelayed({ revealGem(blueGem) }, 4000L)
-        handler.postDelayed({ revealGem(turquoiseGem) }, 5000L)
-        handler.postDelayed({ revealGem(greenGem) }, 6000L)
-    }
-
-    private fun playSceneTwo() {
-        stopGlow(redGem)
-        stopGlow(blueGem)
-        stopGlow(turquoiseGem)
-        stopGlow(greenGem)
-        fadeOutView(redGem)
-        fadeOutView(blueGem)
-        fadeOutView(turquoiseGem)
-        fadeOutView(greenGem)
-
-        showSubtitle("But balance is a chain meant to be broken… and I, the Black Wizard, will forge a new world from the ashes.")
-        fadeInCharacter(blackWizard, wizardAura)
-
-        playAudio(R.raw.a2) {
-            startScene(2)
-        }
-    }
-
-    private fun playSceneThree() {
-        fadeOutCharacter(blackWizard, wizardAura)
-        showSubtitle("Yet hope remains. A lone guardian rises, chosen by the runes themselves, to stand against the growing darkness.")
-        fadeInCharacter(elfGuardian, elfAura)
-
-        playAudio(R.raw.a3) {
-            startScene(3)
-        }
-    }
-
-    private fun playSceneFour() {
-        val offset = resources.displayMetrics.widthPixels * 0.28f
-
-        showSubtitle("The battle of Fire, Water, Air, and Earth has begun!")
-
-        showFinalCharacter(blackWizard, wizardAura, offset)
-        showFinalCharacter(elfGuardian, elfAura, -offset)
-
-        prepareGemsForScene()
-        revealGem(redGem)
-        revealGem(blueGem)
-        revealGem(turquoiseGem)
-        revealGem(greenGem)
-
-        playAudio(R.raw.a4) {
-            startButton.visibility = View.VISIBLE
-            startButton.alpha = 0f
-            startButton.animate().alpha(1f).setDuration(600L).start()
-        }
-    }
-
-    private fun prepareGemsForScene() {
-        gemRow.visibility = View.VISIBLE
-        listOf(redGem, blueGem, turquoiseGem, greenGem).forEach { gem ->
-            gem.visibility = View.VISIBLE
-            gem.alpha = 0f
-            gem.scaleX = 1f
-            gem.scaleY = 1f
-        }
-    }
-
-    private fun revealGem(gem: ImageView) {
-        gem.animate().cancel()
-        gem.visibility = View.VISIBLE
-        gem.alpha = 0f
-        gem.animate()
-            .alpha(1f)
-            .setDuration(500L)
-            .withEndAction { startGlow(gem) }
-            .start()
-    }
-
-    private fun fadeOutView(view: View) {
-        view.animate().cancel()
-        view.animate()
-            .alpha(0f)
-            .setDuration(400L)
-            .withEndAction {
-                view.visibility = View.GONE
-            }
-            .start()
-    }
-
-    private fun fadeInCharacter(character: ImageView, aura: ImageView) {
-        character.animate().cancel()
-        aura.animate().cancel()
-
-        character.translationX = 0f
-        aura.translationX = 0f
-
-        aura.visibility = View.VISIBLE
-        aura.alpha = 0f
-        aura.animate()
-            .alpha(1f)
-            .setDuration(600L)
-            .withEndAction { startGlow(aura) }
-            .start()
-
-        character.visibility = View.VISIBLE
-        character.alpha = 0f
-        character.animate()
-            .alpha(1f)
-            .setDuration(600L)
-            .start()
-    }
-
-    private fun fadeOutCharacter(character: ImageView, aura: ImageView) {
-        stopGlow(aura)
-        stopGlow(character)
-        character.animate().cancel()
-        aura.animate().cancel()
-
-        character.animate()
-            .alpha(0f)
-            .setDuration(500L)
-            .withEndAction {
-                character.visibility = View.GONE
-            }
-            .start()
-
-        aura.animate()
-            .alpha(0f)
-            .setDuration(500L)
-            .withEndAction {
-                aura.visibility = View.GONE
-            }
-            .start()
-    }
-
-    private fun showFinalCharacter(character: ImageView, aura: ImageView, translationX: Float) {
-        stopGlow(aura)
-        stopGlow(character)
-        character.animate().cancel()
-        aura.animate().cancel()
-
-        aura.visibility = View.VISIBLE
-        aura.alpha = 0f
-        aura.translationX = translationX
-        aura.animate()
-            .alpha(1f)
-            .setDuration(600L)
-            .withEndAction { startGlow(aura) }
-            .start()
-
-        character.visibility = View.VISIBLE
-        character.alpha = 0f
-        character.translationX = translationX
-        character.animate()
-            .alpha(1f)
-            .setDuration(600L)
-            .start()
-    }
-
-    private fun showSubtitle(text: String) {
-        subtitleText.visibility = View.VISIBLE
-        subtitleText.animate().cancel()
-        subtitleText.alpha = 0f
-        subtitleText.text = text
-        subtitleText.animate().alpha(1f).setDuration(400L).start()
-    }
-
-    private fun playAudio(resId: Int, onComplete: () -> Unit) {
-        mediaPlayer?.release()
-        mediaPlayer = MediaPlayer.create(this, resId).apply {
-            setOnCompletionListener {
-                onComplete()
-            }
-            start()
-        }
-    }
-
-    private fun startGlow(view: View) {
-        stopGlow(view)
-        val animator = ValueAnimator.ofFloat(1f, 1.1f, 1f).apply {
-            duration = 1200L
-            repeatCount = ValueAnimator.INFINITE
-            addUpdateListener { valueAnimator ->
-                val scale = valueAnimator.animatedValue as Float
-                view.scaleX = scale
-                view.scaleY = scale
-            }
-        }
-        animator.start()
-        glowAnimators[view] = animator
-    }
-
-    private fun stopGlow(view: View) {
-        glowAnimators.remove(view)?.cancel()
-        view.scaleX = 1f
-        view.scaleY = 1f
+    companion object {
+        const val EXTRA_SELECTED_HERO = "selected_hero"
+        private const val VILLAIN_ASSET_PATH = "characters/black_mage.png"
     }
 }

--- a/app/src/main/java/com/example/rouneboundmagic/MainActivity.kt
+++ b/app/src/main/java/com/example/rouneboundmagic/MainActivity.kt
@@ -22,6 +22,7 @@ class MainActivity : GameActivity() {
 
     companion object {
         private const val TAG = "MainActivity"
+        const val EXTRA_SELECTED_HERO = "selected_hero"
 
         init {
                 System.loadLibrary("rouneboundmagic")

--- a/app/src/main/java/com/example/rouneboundmagic/StartGameActivity.kt
+++ b/app/src/main/java/com/example/rouneboundmagic/StartGameActivity.kt
@@ -1,0 +1,20 @@
+package com.example.rouneboundmagic
+
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Button
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.WindowCompat
+
+class StartGameActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        setContentView(R.layout.activity_start_game)
+
+        val startPlayButton: Button = findViewById(R.id.startPlayButton)
+        startPlayButton.setOnClickListener {
+            startActivity(Intent(this, CharacterSelectionActivity::class.java))
+        }
+    }
+}

--- a/app/src/main/res/drawable/card_background.xml
+++ b/app/src/main/res/drawable/card_background.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#222222" />
+    <corners android:radius="12dp" />
+    <stroke
+        android:width="2dp"
+        android:color="#66FFFFFF" />
+</shape>

--- a/app/src/main/res/drawable/rune_placeholder_background.xml
+++ b/app/src/main/res/drawable/rune_placeholder_background.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#101010" />
+    <corners android:radius="16dp" />
+    <stroke
+        android:width="2dp"
+        android:color="#33FFFFFF" />
+    <size
+        android:height="0dp"
+        android:width="0dp" />
+</shape>

--- a/app/src/main/res/layout/activity_character_selection.xml
+++ b/app/src/main/res/layout/activity_character_selection.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@android:color/black">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="24dp">
+
+        <TextView
+            android:id="@+id/selectionTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:text="@string/select_hero"
+            android:textColor="@android:color/white"
+            android:textSize="22sp"
+            android:textStyle="bold"
+            android:paddingBottom="16dp" />
+
+        <androidx.gridlayout.widget.GridLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:alignmentMode="alignBounds"
+            android:columnCount="2"
+            android:rowCount="2"
+            android:rowOrderPreserved="false"
+            android:useDefaultMargins="true">
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_columnWeight="1"
+                android:layout_rowWeight="1"
+                android:orientation="vertical"
+                android:padding="8dp">
+
+                <ImageView
+                    android:id="@+id/warriorCard"
+                    android:layout_width="match_parent"
+                    android:layout_height="200dp"
+                    android:adjustViewBounds="true"
+                    android:background="@drawable/card_background"
+                    android:scaleType="centerCrop" />
+
+                <TextView
+                    android:id="@+id/warriorLabel"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center"
+                    android:textColor="@android:color/white"
+                    android:textSize="16sp"
+                    android:paddingTop="8dp" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_columnWeight="1"
+                android:layout_rowWeight="1"
+                android:orientation="vertical"
+                android:padding="8dp">
+
+                <ImageView
+                    android:id="@+id/mageCard"
+                    android:layout_width="match_parent"
+                    android:layout_height="200dp"
+                    android:adjustViewBounds="true"
+                    android:background="@drawable/card_background"
+                    android:scaleType="centerCrop" />
+
+                <TextView
+                    android:id="@+id/mageLabel"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center"
+                    android:textColor="@android:color/white"
+                    android:textSize="16sp"
+                    android:paddingTop="8dp" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_columnWeight="1"
+                android:layout_rowWeight="1"
+                android:orientation="vertical"
+                android:padding="8dp">
+
+                <ImageView
+                    android:id="@+id/priestessCard"
+                    android:layout_width="match_parent"
+                    android:layout_height="200dp"
+                    android:adjustViewBounds="true"
+                    android:background="@drawable/card_background"
+                    android:scaleType="centerCrop" />
+
+                <TextView
+                    android:id="@+id/priestessLabel"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center"
+                    android:textColor="@android:color/white"
+                    android:textSize="16sp"
+                    android:paddingTop="8dp" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_columnWeight="1"
+                android:layout_rowWeight="1"
+                android:orientation="vertical"
+                android:padding="8dp">
+
+                <ImageView
+                    android:id="@+id/rangerCard"
+                    android:layout_width="match_parent"
+                    android:layout_height="200dp"
+                    android:adjustViewBounds="true"
+                    android:background="@drawable/card_background"
+                    android:scaleType="centerCrop" />
+
+                <TextView
+                    android:id="@+id/rangerLabel"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center"
+                    android:textColor="@android:color/white"
+                    android:textSize="16sp"
+                    android:paddingTop="8dp" />
+            </LinearLayout>
+
+        </androidx.gridlayout.widget.GridLayout>
+
+    </LinearLayout>
+
+</ScrollView>

--- a/app/src/main/res/layout/activity_intro.xml
+++ b/app/src/main/res/layout/activity_intro.xml
@@ -1,111 +1,89 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@android:color/black">
+    android:background="@android:color/black"
+    android:padding="24dp">
 
     <ImageView
-        android:id="@+id/backgroundImage"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:scaleType="centerCrop" />
-
-    <ImageView
-        android:id="@+id/wizardAura"
-        android:layout_width="280dp"
-        android:layout_height="280dp"
-        android:layout_gravity="center"
-        android:alpha="0"
-        android:src="@drawable/green_aura"
-        android:visibility="gone" />
-
-    <ImageView
-        android:id="@+id/elfAura"
-        android:layout_width="280dp"
-        android:layout_height="280dp"
-        android:layout_gravity="center"
-        android:alpha="0"
-        android:src="@drawable/golden_aura"
-        android:visibility="gone" />
-
-    <ImageView
-        android:id="@+id/blackWizard"
-        android:layout_width="220dp"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
+        android:id="@+id/heroCard"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
         android:adjustViewBounds="true"
-        android:alpha="0"
-        android:visibility="gone" />
-
-    <ImageView
-        android:id="@+id/elfGuardian"
-        android:layout_width="220dp"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:adjustViewBounds="true"
-        android:alpha="0"
-        android:visibility="gone" />
+        android:background="@drawable/card_background"
+        android:scaleType="centerCrop"
+        app:layout_constraintBottom_toTopOf="@+id/heroInfoContainer"
+        app:layout_constraintDimensionRatio="3:4"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <LinearLayout
-        android:id="@+id/gemRow"
-        android:layout_width="wrap_content"
+        android:id="@+id/heroInfoContainer"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:gravity="center"
-        android:orientation="horizontal"
-        android:visibility="visible">
+        android:layout_marginTop="12dp"
+        android:orientation="vertical"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/heroCard">
 
-        <ImageView
-            android:id="@+id/redGem"
-            android:layout_width="96dp"
-            android:layout_height="96dp"
-            android:alpha="0"
-            android:padding="8dp" />
+        <TextView
+            android:id="@+id/heroName"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:textColor="@android:color/white"
+            android:textSize="20sp"
+            android:textStyle="bold" />
 
-        <ImageView
-            android:id="@+id/blueGem"
-            android:layout_width="96dp"
-            android:layout_height="96dp"
-            android:alpha="0"
-            android:padding="8dp" />
-
-        <ImageView
-            android:id="@+id/turquoiseGem"
-            android:layout_width="96dp"
-            android:layout_height="96dp"
-            android:alpha="0"
-            android:padding="8dp" />
-
-        <ImageView
-            android:id="@+id/greenGem"
-            android:layout_width="96dp"
-            android:layout_height="96dp"
-            android:alpha="0"
-            android:padding="8dp" />
+        <TextView
+            android:id="@+id/heroDescription"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:paddingTop="4dp"
+            android:textColor="@android:color/darker_gray"
+            android:textSize="14sp" />
     </LinearLayout>
 
-    <TextView
-        android:id="@+id/subtitleText"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal|bottom"
-        android:layout_margin="32dp"
-        android:alpha="0"
-        android:gravity="center"
-        android:textColor="@android:color/white"
-        android:textSize="18sp"
-        android:textStyle="bold"
-        android:visibility="gone" />
+    <FrameLayout
+        android:id="@+id/runePlaceholder"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="24dp"
+        android:layout_marginBottom="24dp"
+        android:background="@drawable/rune_placeholder_background"
+        app:layout_constraintDimensionRatio="1:0.6"
+        app:layout_constraintBottom_toTopOf="@id/villainCard"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/heroInfoContainer" />
+
+    <ImageView
+        android:id="@+id/villainCard"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:adjustViewBounds="true"
+        android:background="@drawable/card_background"
+        android:scaleType="centerCrop"
+        app:layout_constraintBottom_toTopOf="@id/continueButton"
+        app:layout_constraintDimensionRatio="3:4"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/runePlaceholder" />
 
     <Button
-        android:id="@+id/startButton"
+        android:id="@+id/continueButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal|bottom"
-        android:layout_marginBottom="48dp"
-        android:backgroundTint="@android:color/holo_purple"
-        android:text="@string/start_game"
-        android:textColor="@android:color/white"
-        android:visibility="gone" />
+        android:text="@string/continue_to_battle"
+        android:textAllCaps="false"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/villainCard"
+        app:layout_constraintVertical_bias="0" />
 
-</FrameLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_start_game.xml
+++ b/app/src/main/res/layout/activity_start_game.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@android:color/black">
+
+    <TextView
+        android:id="@+id/gameTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/game_title"
+        android:textColor="@android:color/white"
+        android:textSize="28sp"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toTopOf="@id/startPlayButton"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.4" />
+
+    <Button
+        android:id="@+id/startPlayButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/start_play"
+        android:textAllCaps="false"
+        android:textSize="18sp"
+        android:paddingStart="32dp"
+        android:paddingEnd="32dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/gameTitle"
+        app:layout_constraintVertical_bias="0.1" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,16 @@
 <resources>
     <string name="app_name">Rounebound Magic</string>
     <string name="start_game">Start Game</string>
+    <string name="game_title">Rounebound Magic</string>
+    <string name="start_play">Start Play</string>
+    <string name="select_hero">Επίλεξε τον Ήρωά σου</string>
+    <string name="hero_warrior">Warrior</string>
+    <string name="hero_mage">Mage</string>
+    <string name="hero_priestess">Mystical Priestess</string>
+    <string name="hero_ranger">Ranger</string>
+    <string name="hero_warrior_desc">Δυνατός μαχητής με σπαθί.</string>
+    <string name="hero_mage_desc">Κυρίαρχος των ρούνων και της μαγείας.</string>
+    <string name="hero_priestess_desc">Θεραπεύτρια, σύμμαχος του φωτός.</string>
+    <string name="hero_ranger_desc">Τοξότης με υψηλή ευκινησία.</string>
+    <string name="continue_to_battle">Συνέχεια στη μάχη</string>
 </resources>


### PR DESCRIPTION
## Summary
- add a launcher StartGameActivity that opens the new character selection screen
- implement hero card selection with asset-backed artwork and descriptions
- refresh the intro scene to show the chosen hero against the Black Mage and keep a rune play area placeholder

## Testing
- `./gradlew lint` *(fails: missing Android SDK in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68daad1d6b7c83288f6f208e0172402e