### PR TITLE
Implement interactive lobby background

### DIFF
--- a/app/src/main/java/com/example/rouneboundmagic/StartGameActivity.kt
+++ b/app/src/main/java/com/example/rouneboundmagic/StartGameActivity.kt
@@ -1,20 +1,53 @@
 package com.example.rouneboundmagic
 
 import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.os.Bundle
-import android.widget.Button
+import android.view.View
+import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.WindowCompat
 
 class StartGameActivity : AppCompatActivity() {
+    private var lobbyBackgroundBitmap: Bitmap? = null
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         WindowCompat.setDecorFitsSystemWindows(window, false)
         setContentView(R.layout.activity_start_game)
 
-        val startPlayButton: Button = findViewById(R.id.startPlayButton)
-        startPlayButton.setOnClickListener {
+        val backgroundView: ImageView = findViewById(R.id.lobbyBackground)
+        lobbyBackgroundBitmap = loadLobbyBackground()
+        lobbyBackgroundBitmap?.let(backgroundView::setImageBitmap)
+
+        findViewById<View>(R.id.selectHeroHotspot).setOnClickListener {
             startActivity(Intent(this, CharacterSelectionActivity::class.java))
         }
+
+        findViewById<View>(R.id.backHotspot).setOnClickListener {
+            startActivity(Intent(this, IntroActivity::class.java))
+            finish()
+        }
+
+        findViewById<View>(R.id.startBattleHotspot).setOnClickListener {
+            startActivity(Intent(this, MainActivity::class.java))
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        lobbyBackgroundBitmap?.recycle()
+        lobbyBackgroundBitmap = null
+    }
+
+    private fun loadLobbyBackground(): Bitmap? {
+        return runCatching {
+            assets.open(LOBBY_BACKGROUND_ASSET).use(BitmapFactory::decodeStream)
+        }.getOrNull()
+    }
+
+    companion object {
+        private const val LOBBY_BACKGROUND_ASSET = "lobby/Game_Lobby.png"
     }
 }

--- a/app/src/main/res/layout/activity_start_game.xml
+++ b/app/src/main/res/layout/activity_start_game.xml
@@ -2,36 +2,68 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@android:color/black">
+    android:layout_height="match_parent">
 
-    <TextView
-        android:id="@+id/gameTitle"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/game_title"
-        android:textColor="@android:color/white"
-        android:textSize="28sp"
-        android:textStyle="bold"
-        app:layout_constraintBottom_toTopOf="@id/startPlayButton"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.4" />
-
-    <Button
-        android:id="@+id/startPlayButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/start_play"
-        android:textAllCaps="false"
-        android:textSize="18sp"
-        android:paddingStart="32dp"
-        android:paddingEnd="32dp"
+    <ImageView
+        android:id="@+id/lobbyBackground"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:contentDescription="@null"
+        android:scaleType="centerCrop"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/gameTitle"
-        app:layout_constraintVertical_bias="0.1" />
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <View
+        android:id="@+id/selectHeroHotspot"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="@android:color/transparent"
+        android:clickable="true"
+        android:contentDescription="@string/lobby_select_hero"
+        android:focusable="true"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHeight_percent="0.12"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.82"
+        app:layout_constraintWidth_percent="0.4" />
+
+    <View
+        android:id="@+id/backHotspot"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="@android:color/transparent"
+        android:clickable="true"
+        android:contentDescription="@string/lobby_back"
+        android:focusable="true"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHeight_percent="0.12"
+        app:layout_constraintHorizontal_bias="0.12"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.92"
+        app:layout_constraintWidth_percent="0.26" />
+
+    <View
+        android:id="@+id/startBattleHotspot"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="@android:color/transparent"
+        android:clickable="true"
+        android:contentDescription="@string/lobby_start_battle"
+        android:focusable="true"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHeight_percent="0.12"
+        app:layout_constraintHorizontal_bias="0.88"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.92"
+        app:layout_constraintWidth_percent="0.28" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,9 @@
     <string name="start_game">Start Game</string>
     <string name="game_title">Rounebound Magic</string>
     <string name="start_play">Start Play</string>
+    <string name="lobby_select_hero">Επιλογή Ήρωα</string>
+    <string name="lobby_back">Επιστροφή στην εισαγωγή</string>
+    <string name="lobby_start_battle">Έναρξη Μάχης</string>
     <string name="select_hero">Επίλεξε τον Ήρωά σου</string>
     <string name="hero_warrior">Warrior</string>
     <string name="hero_mage">Mage</string>


### PR DESCRIPTION
## Summary
- load the lobby background artwork from assets and stretch it to the full screen
- overlay transparent hotspots that align with the artwork buttons for hero selection, back, and battle start
- hook the hotspots up to their navigation targets and recycle the loaded bitmap

## Testing
- ./gradlew lint *(fails: Android SDK not installed in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dac74aadbc8328b184afeeeaeeec84