### PR TITLE
Implement cinematic intro and lobby hero selection flow

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,13 +17,13 @@
             android:exported="false"
             android:launchMode="singleTop" />
         <activity
-            android:name=".IntroActivity"
-            android:exported="false" />
-        <activity
             android:name=".CharacterSelectionActivity"
             android:exported="false" />
         <activity
             android:name=".StartGameActivity"
+            android:exported="false" />
+        <activity
+            android:name=".IntroActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/example/rouneboundmagic/CharacterSelectionActivity.kt
+++ b/app/src/main/java/com/example/rouneboundmagic/CharacterSelectionActivity.kt
@@ -1,6 +1,6 @@
 package com.example.rouneboundmagic
 
-import android.content.Intent
+import android.app.Activity
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.os.Bundle
@@ -8,36 +8,43 @@ import android.widget.ImageView
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.WindowCompat
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.card.MaterialCardView
 
 class CharacterSelectionActivity : AppCompatActivity() {
 
     private val heroBitmaps = mutableMapOf<String, Bitmap>()
+    private lateinit var confirmButton: MaterialButton
+    private lateinit var cancelButton: MaterialButton
+
+    private val heroCards = mutableMapOf<HeroOption, MaterialCardView>()
+    private var selectedHero: HeroOption? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         WindowCompat.setDecorFitsSystemWindows(window, false)
         setContentView(R.layout.activity_character_selection)
 
-        setupHeroCard(
-            imageId = R.id.warriorCard,
-            labelId = R.id.warriorLabel,
-            hero = HeroOption.WARRIOR
-        )
-        setupHeroCard(
-            imageId = R.id.mageCard,
-            labelId = R.id.mageLabel,
-            hero = HeroOption.MAGE
-        )
-        setupHeroCard(
-            imageId = R.id.priestessCard,
-            labelId = R.id.priestessLabel,
-            hero = HeroOption.MYSTICAL_PRIESTESS
-        )
-        setupHeroCard(
-            imageId = R.id.rangerCard,
-            labelId = R.id.rangerLabel,
-            hero = HeroOption.RANGER
-        )
+        confirmButton = findViewById(R.id.confirmSelectionButton)
+        cancelButton = findViewById(R.id.cancelSelectionButton)
+
+        confirmButton.isEnabled = false
+        confirmButton.setOnClickListener { returnSelection() }
+        cancelButton.setOnClickListener { finish() }
+
+        setupHeroCard(R.id.cardWarrior, R.id.heroImageWarrior, R.id.heroLabelWarrior, HeroOption.WARRIOR)
+        setupHeroCard(R.id.cardMage, R.id.heroImageMage, R.id.heroLabelMage, HeroOption.MAGE)
+        setupHeroCard(R.id.cardPriestess, R.id.heroImagePriestess, R.id.heroLabelPriestess, HeroOption.MYSTICAL_PRIESTESS)
+        setupHeroCard(R.id.cardRanger, R.id.heroImageRanger, R.id.heroLabelRanger, HeroOption.RANGER)
+
+        selectedHero = savedInstanceState?.getString(KEY_SELECTED_HERO)?.let(HeroOption::fromName)
+            ?: intent.getStringExtra(EXTRA_SELECTED_HERO)?.let(HeroOption::fromName)
+        selectedHero?.let { highlightSelection(it) }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putString(KEY_SELECTED_HERO, selectedHero?.name)
     }
 
     override fun onDestroy() {
@@ -46,30 +53,61 @@ class CharacterSelectionActivity : AppCompatActivity() {
         heroBitmaps.clear()
     }
 
-    private fun setupHeroCard(imageId: Int, labelId: Int, hero: HeroOption) {
-        val imageView: ImageView = findViewById(imageId)
-        val labelView: TextView = findViewById(labelId)
+    private fun setupHeroCard(cardId: Int, imageId: Int, labelId: Int, hero: HeroOption) {
+        val card: MaterialCardView = findViewById(cardId)
+        val heroImage: ImageView = findViewById(imageId)
+        val heroLabel: TextView = findViewById(labelId)
 
-        labelView.text = getString(hero.displayNameRes)
-        imageView.setImageBitmap(loadBitmap(hero.assetPath))
-        imageView.setOnClickListener { onHeroSelected(hero) }
+        heroImage.setImageBitmap(loadBitmap(hero.assetPath))
+        heroLabel.text = getString(hero.displayNameRes)
+
+        card.setOnClickListener {
+            highlightSelection(hero)
+        }
+        heroCards[hero] = card
     }
 
-    private fun onHeroSelected(hero: HeroOption) {
-        val intent = Intent(this, IntroActivity::class.java)
-        intent.putExtra(IntroActivity.EXTRA_SELECTED_HERO, hero.name)
-        startActivity(intent)
+    private fun highlightSelection(hero: HeroOption) {
+        selectedHero = hero
+        heroCards.forEach { (option, card) ->
+            val isSelected = option == hero
+            card.strokeWidth = if (isSelected) {
+                resources.getDimensionPixelSize(R.dimen.hero_card_stroke_width)
+            } else {
+                0
+            }
+            card.strokeColor = if (isSelected) {
+                getColor(R.color.teal_200)
+            } else {
+                getColor(android.R.color.transparent)
+            }
+            card.cardElevation = if (isSelected) 12f else 4f
+        }
+        confirmButton.isEnabled = true
+    }
+
+    private fun returnSelection() {
+        val hero = selectedHero ?: return
+        setResult(
+            Activity.RESULT_OK,
+            android.content.Intent().putExtra(EXTRA_SELECTED_HERO, hero.name)
+        )
+        finish()
     }
 
     private fun loadBitmap(path: String): Bitmap? {
-        return heroBitmaps[path] ?: run {
-            val bitmap = runCatching {
-                assets.open(path).use(BitmapFactory::decodeStream)
-            }.getOrNull()
-            if (bitmap != null) {
-                heroBitmaps[path] = bitmap
-            }
-            bitmap
+        heroBitmaps[path]?.let { return it }
+        val bitmap = runCatching {
+            assets.open(path).use(BitmapFactory::decodeStream)
+        }.getOrNull()
+        if (bitmap != null) {
+            heroBitmaps[path] = bitmap
         }
+        return bitmap
+    }
+
+    companion object {
+        const val EXTRA_SELECTED_HERO = "selected_hero"
+        private const val KEY_SELECTED_HERO = "key_selected_hero"
     }
 }

--- a/app/src/main/java/com/example/rouneboundmagic/IntroActivity.kt
+++ b/app/src/main/java/com/example/rouneboundmagic/IntroActivity.kt
@@ -3,77 +3,262 @@ package com.example.rouneboundmagic
 import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
-import android.graphics.drawable.BitmapDrawable
+import android.media.MediaPlayer
 import android.os.Bundle
-import android.widget.Button
+import android.os.Handler
+import android.os.Looper
+import android.view.View
+import android.view.animation.AccelerateDecelerateInterpolator
 import android.widget.ImageView
-import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.isVisible
 import androidx.core.view.WindowCompat
+import com.google.android.material.button.MaterialButton
 
 class IntroActivity : AppCompatActivity() {
 
-    private lateinit var heroCardView: ImageView
-    private lateinit var heroNameView: TextView
-    private lateinit var heroDescriptionView: TextView
-    private lateinit var villainCardView: ImageView
-    private lateinit var continueButton: Button
-    private lateinit var selectedHero: HeroOption
+    private lateinit var startButton: MaterialButton
+    private lateinit var backgroundView: ImageView
+    private lateinit var runeFireView: ImageView
+    private lateinit var runeWaterView: ImageView
+    private lateinit var runeAirView: ImageView
+    private lateinit var runeEarthView: ImageView
+    private lateinit var mageGroup: View
+    private lateinit var magePortrait: ImageView
+    private lateinit var priestessGroup: View
+    private lateinit var priestessPortrait: ImageView
 
-    private var heroBitmap: Bitmap? = null
-    private var villainBitmap: Bitmap? = null
+    private val handler = Handler(Looper.getMainLooper())
+    private val scheduledTasks = mutableListOf<Runnable>()
+    private val glowAnimators = mutableListOf<android.animation.ValueAnimator>()
+    private val activeBitmaps = mutableListOf<Bitmap>()
+    private val narrationQueue = ArrayDeque(listOf(R.raw.a1, R.raw.a2, R.raw.a3, R.raw.a4))
+    private var mediaPlayer: MediaPlayer? = null
+    private var introCompleted = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         WindowCompat.setDecorFitsSystemWindows(window, false)
         setContentView(R.layout.activity_intro)
 
-        heroCardView = findViewById(R.id.heroCard)
-        heroNameView = findViewById(R.id.heroName)
-        heroDescriptionView = findViewById(R.id.heroDescription)
-        villainCardView = findViewById(R.id.villainCard)
-        continueButton = findViewById(R.id.continueButton)
-
-        selectedHero = HeroOption.fromName(intent.getStringExtra(EXTRA_SELECTED_HERO))
-        bindHero(selectedHero)
-        bindVillain()
-
-        continueButton.setOnClickListener {
-            val intent = Intent(this, MainActivity::class.java)
-            intent.putExtra(MainActivity.EXTRA_SELECTED_HERO, selectedHero.name)
-            startActivity(intent)
-            finish()
+        bindViews()
+        loadArtwork()
+        val alreadyFinished = prepareInitialState(savedInstanceState)
+        setupStartButton()
+        if (!alreadyFinished) {
+            scheduleRuneReveals()
+            playNextNarration()
         }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putBoolean(KEY_MAGE_VISIBLE, mageGroup.isVisible)
+        outState.putBoolean(KEY_PRIESTESS_VISIBLE, priestessGroup.isVisible)
+        outState.putBoolean(KEY_INTRO_FINISHED, introCompleted)
     }
 
     override fun onDestroy() {
         super.onDestroy()
-        heroBitmap?.recycle()
-        heroBitmap = null
-        villainBitmap?.recycle()
-        villainBitmap = null
+        cancelScheduledTasks()
+        releaseNarration()
+        releaseBitmaps()
+        glowAnimators.forEach { it.cancel() }
+        glowAnimators.clear()
     }
 
-    private fun bindHero(hero: HeroOption) {
-        heroNameView.text = getString(hero.displayNameRes)
-        heroDescriptionView.text = getString(hero.descriptionRes)
-        heroBitmap = loadBitmap(hero.assetPath)
-        heroBitmap?.let { heroCardView.setImageDrawable(BitmapDrawable(resources, it)) }
+    private fun bindViews() {
+        backgroundView = findViewById(R.id.introBackground)
+        runeFireView = findViewById(R.id.runeFire)
+        runeWaterView = findViewById(R.id.runeWater)
+        runeAirView = findViewById(R.id.runeAir)
+        runeEarthView = findViewById(R.id.runeEarth)
+        mageGroup = findViewById(R.id.mageContainer)
+        magePortrait = findViewById(R.id.magePortrait)
+        priestessGroup = findViewById(R.id.priestessContainer)
+        priestessPortrait = findViewById(R.id.priestessPortrait)
+        startButton = findViewById(R.id.startGameButton)
     }
 
-    private fun bindVillain() {
-        villainBitmap = loadBitmap(VILLAIN_ASSET_PATH)
-        villainBitmap?.let { villainCardView.setImageDrawable(BitmapDrawable(resources, it)) }
+    private fun loadArtwork() {
+        backgroundView.setImageBitmap(loadBitmap("intro/MysticalTempleRuins"))
+        runeFireView.setImageBitmap(loadBitmap("puzzle/red_gem.png"))
+        runeWaterView.setImageBitmap(loadBitmap("puzzle/blue_gem.png"))
+        runeAirView.setImageBitmap(loadBitmap("puzzle/turquoise.png"))
+        runeEarthView.setImageBitmap(loadBitmap("puzzle/green_gem.png"))
+        magePortrait.setImageBitmap(loadBitmap("characters/black_mage.png"))
+        priestessPortrait.setImageBitmap(loadBitmap("characters/mystical_priestess.png"))
+    }
+
+    private fun prepareInitialState(savedInstanceState: Bundle?): Boolean {
+        introCompleted = savedInstanceState?.getBoolean(KEY_INTRO_FINISHED) == true
+        mageGroup.isVisible = savedInstanceState?.getBoolean(KEY_MAGE_VISIBLE) == true
+        priestessGroup.isVisible = savedInstanceState?.getBoolean(KEY_PRIESTESS_VISIBLE) == true
+        val runeViews = listOf(runeFireView, runeWaterView, runeAirView, runeEarthView)
+        runeViews.forEach { view ->
+            view.scaleX = 0.6f
+            view.scaleY = 0.6f
+            view.alpha = if (introCompleted) 1f else 0f
+            if (!introCompleted) {
+                view.isVisible = false
+            } else {
+                view.isVisible = true
+                view.scaleX = 1f
+                view.scaleY = 1f
+            }
+        }
+        startButton.isVisible = introCompleted
+        startButton.alpha = if (introCompleted) 1f else 0f
+        startButton.isEnabled = introCompleted
+        if (introCompleted) {
+            startRuneGlow(runeFireView)
+            startRuneGlow(runeWaterView)
+            startRuneGlow(runeAirView)
+            startRuneGlow(runeEarthView)
+        }
+        return introCompleted
+    }
+
+    private fun setupStartButton() {
+        startButton.setOnClickListener {
+            startActivity(Intent(this, StartGameActivity::class.java))
+            finish()
+        }
+    }
+
+    private fun scheduleRuneReveals() {
+        schedule(3_000L) { revealRune(runeFireView) }
+        schedule(4_000L) { revealRune(runeWaterView) }
+        schedule(5_000L) { revealRune(runeAirView) }
+        schedule(6_000L) { revealRune(runeEarthView) }
+    }
+
+    private fun schedule(delayMillis: Long, block: () -> Unit) {
+        val runnable = Runnable(block)
+        scheduledTasks += runnable
+        handler.postDelayed(runnable, delayMillis)
+    }
+
+    private fun revealRune(target: ImageView) {
+        target.isVisible = true
+        target.animate()
+            .alpha(1f)
+            .scaleX(1f)
+            .scaleY(1f)
+            .setDuration(320L)
+            .setInterpolator(AccelerateDecelerateInterpolator())
+            .start()
+    }
+
+    private fun playNextNarration() {
+        val nextRes = narrationQueue.removeFirstOrNull() ?: run {
+            onNarrationFinished()
+            return
+        }
+        releaseNarration()
+        mediaPlayer = MediaPlayer.create(this, nextRes).apply {
+            setOnCompletionListener {
+                playNextNarration()
+            }
+            start()
+        }
+        when (nextRes) {
+            R.raw.a2 -> showBlackMage()
+            R.raw.a3 -> showPriestess()
+            R.raw.a4 -> showFinale()
+        }
+    }
+
+    private fun showBlackMage() {
+        mageGroup.isVisible = true
+        mageGroup.alpha = 0f
+        mageGroup.scaleX = 0.85f
+        mageGroup.scaleY = 0.85f
+        mageGroup.animate()
+            .alpha(1f)
+            .scaleX(1f)
+            .scaleY(1f)
+            .setDuration(420L)
+            .setInterpolator(AccelerateDecelerateInterpolator())
+            .start()
+    }
+
+    private fun showPriestess() {
+        priestessGroup.isVisible = true
+        priestessGroup.alpha = 0f
+        priestessGroup.animate()
+            .alpha(1f)
+            .setDuration(420L)
+            .setInterpolator(AccelerateDecelerateInterpolator())
+            .start()
+    }
+
+    private fun showFinale() {
+        mageGroup.isVisible = true
+        priestessGroup.isVisible = true
+        startRuneGlow(runeFireView)
+        startRuneGlow(runeWaterView)
+        startRuneGlow(runeAirView)
+        startRuneGlow(runeEarthView)
+    }
+
+    private fun startRuneGlow(target: ImageView) {
+        target.isVisible = true
+        val animator = android.animation.ValueAnimator.ofFloat(0.85f, 1.05f).apply {
+            duration = 900L
+            interpolator = AccelerateDecelerateInterpolator()
+            repeatCount = android.animation.ValueAnimator.INFINITE
+            repeatMode = android.animation.ValueAnimator.REVERSE
+            addUpdateListener { animation ->
+                val scale = animation.animatedValue as Float
+                target.scaleX = scale
+                target.scaleY = scale
+                target.alpha = 0.6f + (scale - 0.85f) * 1.2f
+            }
+            start()
+        }
+        glowAnimators += animator
+    }
+
+    private fun onNarrationFinished() {
+        introCompleted = true
+        startButton.isVisible = true
+        startButton.alpha = 0f
+        startButton.animate()
+            .alpha(1f)
+            .setDuration(450L)
+            .setInterpolator(AccelerateDecelerateInterpolator())
+            .withEndAction { startButton.isEnabled = true }
+            .start()
+    }
+
+    private fun releaseNarration() {
+        mediaPlayer?.setOnCompletionListener(null)
+        mediaPlayer?.release()
+        mediaPlayer = null
+    }
+
+    private fun cancelScheduledTasks() {
+        scheduledTasks.forEach(handler::removeCallbacks)
+        scheduledTasks.clear()
+    }
+
+    private fun releaseBitmaps() {
+        activeBitmaps.forEach(Bitmap::recycle)
+        activeBitmaps.clear()
     }
 
     private fun loadBitmap(path: String): Bitmap? {
-        return runCatching {
+        val bitmap = runCatching {
             assets.open(path).use(BitmapFactory::decodeStream)
         }.getOrNull()
+        bitmap?.let(activeBitmaps::add)
+        return bitmap
     }
 
     companion object {
-        const val EXTRA_SELECTED_HERO = "selected_hero"
-        private const val VILLAIN_ASSET_PATH = "characters/black_mage.png"
+        private const val KEY_MAGE_VISIBLE = "mage_visible"
+        private const val KEY_PRIESTESS_VISIBLE = "priestess_visible"
+        private const val KEY_INTRO_FINISHED = "intro_finished"
     }
 }

--- a/app/src/main/java/com/example/rouneboundmagic/StartGameActivity.kt
+++ b/app/src/main/java/com/example/rouneboundmagic/StartGameActivity.kt
@@ -1,16 +1,34 @@
 package com.example.rouneboundmagic
 
+import android.app.Activity
 import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.os.Bundle
 import android.view.View
 import android.widget.ImageView
+import android.widget.TextView
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.WindowCompat
 
 class StartGameActivity : AppCompatActivity() {
     private var lobbyBackgroundBitmap: Bitmap? = null
+    private var selectedHero: HeroOption? = null
+    private lateinit var selectHeroButton: View
+    private lateinit var startBattleButton: View
+    private lateinit var selectedHeroLabel: TextView
+
+    private val heroSelectionLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        if (result.resultCode == Activity.RESULT_OK) {
+            val heroName = result.data?.getStringExtra(CharacterSelectionActivity.EXTRA_SELECTED_HERO)
+            val hero = HeroOption.fromName(heroName)
+            setSelectedHero(hero)
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -21,17 +39,32 @@ class StartGameActivity : AppCompatActivity() {
         lobbyBackgroundBitmap = loadLobbyBackground()
         lobbyBackgroundBitmap?.let(backgroundView::setImageBitmap)
 
-        findViewById<View>(R.id.selectHeroHotspot).setOnClickListener {
-            startActivity(Intent(this, CharacterSelectionActivity::class.java))
+        selectHeroButton = findViewById(R.id.selectHeroButton)
+        startBattleButton = findViewById(R.id.startBattleButton)
+        selectedHeroLabel = findViewById(R.id.selectedHeroLabel)
+
+        selectedHero = savedInstanceState?.getString(KEY_SELECTED_HERO)?.let(HeroOption::fromName)
+        selectedHero?.let(::setSelectedHero)
+
+        selectHeroButton.setOnClickListener {
+            val intent = Intent(this, CharacterSelectionActivity::class.java)
+            selectedHero?.let { intent.putExtra(CharacterSelectionActivity.EXTRA_SELECTED_HERO, it.name) }
+            heroSelectionLauncher.launch(intent)
         }
 
-        findViewById<View>(R.id.backHotspot).setOnClickListener {
-            startActivity(Intent(this, IntroActivity::class.java))
+        findViewById<View>(R.id.backButton).setOnClickListener {
             finish()
         }
 
-        findViewById<View>(R.id.startBattleHotspot).setOnClickListener {
-            startActivity(Intent(this, MainActivity::class.java))
+        startBattleButton.setOnClickListener {
+            val hero = selectedHero
+            if (hero == null) {
+                Toast.makeText(this, R.string.lobby_select_prompt, Toast.LENGTH_SHORT).show()
+            } else {
+                val intent = Intent(this, MainActivity::class.java)
+                intent.putExtra(MainActivity.EXTRA_SELECTED_HERO, hero.name)
+                startActivity(intent)
+            }
         }
     }
 
@@ -41,13 +74,29 @@ class StartGameActivity : AppCompatActivity() {
         lobbyBackgroundBitmap = null
     }
 
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putString(KEY_SELECTED_HERO, selectedHero?.name)
+    }
+
     private fun loadLobbyBackground(): Bitmap? {
         return runCatching {
             assets.open(LOBBY_BACKGROUND_ASSET).use(BitmapFactory::decodeStream)
         }.getOrNull()
     }
 
+    private fun setSelectedHero(hero: HeroOption) {
+        selectedHero = hero
+        selectHeroButton.isEnabled = true
+        startBattleButton.isEnabled = true
+        selectedHeroLabel.text = getString(R.string.lobby_selected_hero, getString(hero.displayNameRes))
+        if (selectHeroButton is TextView) {
+            (selectHeroButton as TextView).text = getString(R.string.lobby_select_hero_with_choice, getString(hero.displayNameRes))
+        }
+    }
+
     companion object {
         private const val LOBBY_BACKGROUND_ASSET = "lobby/Game_Lobby.png"
+        private const val KEY_SELECTED_HERO = "key_selected_hero"
     }
 }

--- a/app/src/main/res/drawable/character_glow_mage.xml
+++ b/app/src/main/res/drawable/character_glow_mage.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="24dp" />
+    <gradient
+        android:centerColor="#AA1B5E20"
+        android:endColor="#001B5E20"
+        android:startColor="#331B5E20"
+        android:type="radial"
+        android:gradientRadius="260dp" />
+</shape>

--- a/app/src/main/res/drawable/character_glow_priestess.xml
+++ b/app/src/main/res/drawable/character_glow_priestess.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="24dp" />
+    <gradient
+        android:centerColor="#AA2060A8"
+        android:endColor="#002060A8"
+        android:startColor="#332060A8"
+        android:type="radial"
+        android:gradientRadius="260dp" />
+</shape>

--- a/app/src/main/res/drawable/lobby_panel_background.xml
+++ b/app/src/main/res/drawable/lobby_panel_background.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="#AA222222" />
+    <corners android:radius="20dp" />
+    <padding
+        android:left="12dp"
+        android:top="12dp"
+        android:right="12dp"
+        android:bottom="12dp" />
+</shape>

--- a/app/src/main/res/drawable/rune_circle_background.xml
+++ b/app/src/main/res/drawable/rune_circle_background.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="#66000000" />
+    <stroke
+        android:width="2dp"
+        android:color="#88FFFFFF" />
+</shape>

--- a/app/src/main/res/layout/activity_character_selection.xml
+++ b/app/src/main/res/layout/activity_character_selection.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@android:color/black">
@@ -9,133 +10,217 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:padding="24dp">
+        android:padding="24dp"
+        android:gravity="center_horizontal">
 
         <TextView
             android:id="@+id/selectionTitle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal"
+            android:paddingBottom="24dp"
             android:text="@string/select_hero"
             android:textColor="@android:color/white"
             android:textSize="22sp"
-            android:textStyle="bold"
-            android:paddingBottom="16dp" />
+            android:textStyle="bold" />
 
         <androidx.gridlayout.widget.GridLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:alignmentMode="alignBounds"
+            android:alignmentMode="alignMargins"
             android:columnCount="2"
             android:rowCount="2"
-            android:rowOrderPreserved="false"
             android:useDefaultMargins="true">
 
-            <LinearLayout
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/cardWarrior"
+                style="@style/Widget.MaterialComponents.CardView"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_columnWeight="1"
                 android:layout_rowWeight="1"
-                android:orientation="vertical"
-                android:padding="8dp">
+                android:clickable="true"
+                android:focusable="true"
+                android:foreground="?attr/selectableItemBackground"
+                app:cardCornerRadius="@dimen/hero_card_corner_radius"
+                app:cardUseCompatPadding="true"
+                app:strokeColor="@android:color/transparent"
+                app:strokeWidth="0dp">
 
-                <ImageView
-                    android:id="@+id/warriorCard"
-                    android:layout_width="match_parent"
-                    android:layout_height="200dp"
-                    android:adjustViewBounds="true"
-                    android:background="@drawable/card_background"
-                    android:scaleType="centerCrop" />
-
-                <TextView
-                    android:id="@+id/warriorLabel"
+                <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:gravity="center"
-                    android:textColor="@android:color/white"
-                    android:textSize="16sp"
-                    android:paddingTop="8dp" />
-            </LinearLayout>
+                    android:orientation="vertical"
+                    android:padding="12dp">
 
-            <LinearLayout
+                    <ImageView
+                        android:id="@+id/heroImageWarrior"
+                        android:layout_width="match_parent"
+                        android:layout_height="@dimen/hero_card_image_height"
+                        android:adjustViewBounds="true"
+                        android:contentDescription="@string/hero_warrior"
+                        android:scaleType="centerCrop"
+                        tools:src="@drawable/ic_launcher_foreground" />
+
+                    <TextView
+                        android:id="@+id/heroLabelWarrior"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:gravity="center"
+                        android:paddingTop="12dp"
+                        android:textColor="@android:color/white"
+                        android:textSize="16sp" />
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/cardMage"
+                style="@style/Widget.MaterialComponents.CardView"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_columnWeight="1"
                 android:layout_rowWeight="1"
-                android:orientation="vertical"
-                android:padding="8dp">
+                android:clickable="true"
+                android:focusable="true"
+                android:foreground="?attr/selectableItemBackground"
+                app:cardCornerRadius="@dimen/hero_card_corner_radius"
+                app:cardUseCompatPadding="true"
+                app:strokeColor="@android:color/transparent"
+                app:strokeWidth="0dp">
 
-                <ImageView
-                    android:id="@+id/mageCard"
-                    android:layout_width="match_parent"
-                    android:layout_height="200dp"
-                    android:adjustViewBounds="true"
-                    android:background="@drawable/card_background"
-                    android:scaleType="centerCrop" />
-
-                <TextView
-                    android:id="@+id/mageLabel"
+                <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:gravity="center"
-                    android:textColor="@android:color/white"
-                    android:textSize="16sp"
-                    android:paddingTop="8dp" />
-            </LinearLayout>
+                    android:orientation="vertical"
+                    android:padding="12dp">
 
-            <LinearLayout
+                    <ImageView
+                        android:id="@+id/heroImageMage"
+                        android:layout_width="match_parent"
+                        android:layout_height="@dimen/hero_card_image_height"
+                        android:adjustViewBounds="true"
+                        android:contentDescription="@string/hero_mage"
+                        android:scaleType="centerCrop"
+                        tools:src="@drawable/ic_launcher_foreground" />
+
+                    <TextView
+                        android:id="@+id/heroLabelMage"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:gravity="center"
+                        android:paddingTop="12dp"
+                        android:textColor="@android:color/white"
+                        android:textSize="16sp" />
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/cardPriestess"
+                style="@style/Widget.MaterialComponents.CardView"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_columnWeight="1"
                 android:layout_rowWeight="1"
-                android:orientation="vertical"
-                android:padding="8dp">
+                android:clickable="true"
+                android:focusable="true"
+                android:foreground="?attr/selectableItemBackground"
+                app:cardCornerRadius="@dimen/hero_card_corner_radius"
+                app:cardUseCompatPadding="true"
+                app:strokeColor="@android:color/transparent"
+                app:strokeWidth="0dp">
 
-                <ImageView
-                    android:id="@+id/priestessCard"
-                    android:layout_width="match_parent"
-                    android:layout_height="200dp"
-                    android:adjustViewBounds="true"
-                    android:background="@drawable/card_background"
-                    android:scaleType="centerCrop" />
-
-                <TextView
-                    android:id="@+id/priestessLabel"
+                <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:gravity="center"
-                    android:textColor="@android:color/white"
-                    android:textSize="16sp"
-                    android:paddingTop="8dp" />
-            </LinearLayout>
+                    android:orientation="vertical"
+                    android:padding="12dp">
 
-            <LinearLayout
+                    <ImageView
+                        android:id="@+id/heroImagePriestess"
+                        android:layout_width="match_parent"
+                        android:layout_height="@dimen/hero_card_image_height"
+                        android:adjustViewBounds="true"
+                        android:contentDescription="@string/hero_priestess"
+                        android:scaleType="centerCrop"
+                        tools:src="@drawable/ic_launcher_foreground" />
+
+                    <TextView
+                        android:id="@+id/heroLabelPriestess"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:gravity="center"
+                        android:paddingTop="12dp"
+                        android:textColor="@android:color/white"
+                        android:textSize="16sp" />
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/cardRanger"
+                style="@style/Widget.MaterialComponents.CardView"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_columnWeight="1"
                 android:layout_rowWeight="1"
-                android:orientation="vertical"
-                android:padding="8dp">
+                android:clickable="true"
+                android:focusable="true"
+                android:foreground="?attr/selectableItemBackground"
+                app:cardCornerRadius="@dimen/hero_card_corner_radius"
+                app:cardUseCompatPadding="true"
+                app:strokeColor="@android:color/transparent"
+                app:strokeWidth="0dp">
 
-                <ImageView
-                    android:id="@+id/rangerCard"
-                    android:layout_width="match_parent"
-                    android:layout_height="200dp"
-                    android:adjustViewBounds="true"
-                    android:background="@drawable/card_background"
-                    android:scaleType="centerCrop" />
-
-                <TextView
-                    android:id="@+id/rangerLabel"
+                <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:gravity="center"
-                    android:textColor="@android:color/white"
-                    android:textSize="16sp"
-                    android:paddingTop="8dp" />
-            </LinearLayout>
+                    android:orientation="vertical"
+                    android:padding="12dp">
+
+                    <ImageView
+                        android:id="@+id/heroImageRanger"
+                        android:layout_width="match_parent"
+                        android:layout_height="@dimen/hero_card_image_height"
+                        android:adjustViewBounds="true"
+                        android:contentDescription="@string/hero_ranger"
+                        android:scaleType="centerCrop"
+                        tools:src="@drawable/ic_launcher_foreground" />
+
+                    <TextView
+                        android:id="@+id/heroLabelRanger"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:gravity="center"
+                        android:paddingTop="12dp"
+                        android:textColor="@android:color/white"
+                        android:textSize="16sp" />
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
 
         </androidx.gridlayout.widget.GridLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:orientation="horizontal"
+            android:paddingTop="24dp">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/cancelSelectionButton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="12dp"
+                android:layout_weight="1"
+                android:text="@string/hero_cancel_selection"
+                android:textAllCaps="false" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/confirmSelectionButton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/hero_confirm_selection"
+                android:textAllCaps="false" />
+        </LinearLayout>
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/activity_intro.xml
+++ b/app/src/main/res/layout/activity_intro.xml
@@ -1,89 +1,156 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@android:color/black"
-    android:padding="24dp">
+    android:background="@android:color/black">
 
     <ImageView
-        android:id="@+id/heroCard"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:adjustViewBounds="true"
-        android:background="@drawable/card_background"
+        android:id="@+id/introBackground"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:contentDescription="@null"
         android:scaleType="centerCrop"
-        app:layout_constraintBottom_toTopOf="@+id/heroInfoContainer"
-        app:layout_constraintDimensionRatio="3:4"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        tools:src="@drawable/ic_launcher_background" />
 
-    <LinearLayout
-        android:id="@+id/heroInfoContainer"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="12dp"
-        android:orientation="vertical"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/heroCard">
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="#88000000" />
 
-        <TextView
-            android:id="@+id/heroName"
-            android:layout_width="match_parent"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:padding="24dp">
+
+        <FrameLayout
+            android:id="@+id/runeCluster"
+            android:layout_width="220dp"
+            android:layout_height="220dp"
+            android:background="@drawable/rune_circle_background"
+            android:visibility="visible"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.45">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+                <ImageView
+                    android:id="@+id/runeFire"
+                    android:layout_width="72dp"
+                    android:layout_height="72dp"
+                    android:alpha="0"
+                    android:contentDescription="@null"
+                    android:scaleType="fitCenter"
+                    android:visibility="gone"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <ImageView
+                    android:id="@+id/runeWater"
+                    android:layout_width="72dp"
+                    android:layout_height="72dp"
+                    android:alpha="0"
+                    android:contentDescription="@null"
+                    android:scaleType="fitCenter"
+                    android:visibility="gone"
+                    app:layout_constraintBottom_toBottomOf="@id/runeFire"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintVertical_bias="0.1" />
+
+                <ImageView
+                    android:id="@+id/runeAir"
+                    android:layout_width="72dp"
+                    android:layout_height="72dp"
+                    android:alpha="0"
+                    android:contentDescription="@null"
+                    android:scaleType="fitCenter"
+                    android:visibility="gone"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="@id/runeFire"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintHorizontal_bias="0.15" />
+
+                <ImageView
+                    android:id="@+id/runeEarth"
+                    android:layout_width="72dp"
+                    android:layout_height="72dp"
+                    android:alpha="0"
+                    android:contentDescription="@null"
+                    android:scaleType="fitCenter"
+                    android:visibility="gone"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="@id/runeFire"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintHorizontal_bias="0.85" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+        </FrameLayout>
+
+        <FrameLayout
+            android:id="@+id/priestessContainer"
+            android:layout_width="180dp"
+            android:layout_height="300dp"
+            android:layout_marginBottom="36dp"
+            android:background="@drawable/character_glow_priestess"
+            android:padding="12dp"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent">
+
+            <ImageView
+                android:id="@+id/priestessPortrait"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:contentDescription="@string/intro_priestess"
+                android:scaleType="fitCenter" />
+        </FrameLayout>
+
+        <FrameLayout
+            android:id="@+id/mageContainer"
+            android:layout_width="180dp"
+            android:layout_height="300dp"
+            android:layout_marginBottom="36dp"
+            android:background="@drawable/character_glow_mage"
+            android:padding="12dp"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent">
+
+            <ImageView
+                android:id="@+id/magePortrait"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:contentDescription="@string/intro_black_mage"
+                android:scaleType="fitCenter" />
+        </FrameLayout>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/startGameButton"
+            style="@style/Widget.MaterialComponents.Button"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:gravity="center"
-            android:textColor="@android:color/white"
-            android:textSize="20sp"
-            android:textStyle="bold" />
+            android:layout_marginBottom="24dp"
+            android:enabled="false"
+            android:text="@string/intro_start_game"
+            android:textAllCaps="false"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
 
-        <TextView
-            android:id="@+id/heroDescription"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:paddingTop="4dp"
-            android:textColor="@android:color/darker_gray"
-            android:textSize="14sp" />
-    </LinearLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <FrameLayout
-        android:id="@+id/runePlaceholder"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_marginTop="24dp"
-        android:layout_marginBottom="24dp"
-        android:background="@drawable/rune_placeholder_background"
-        app:layout_constraintDimensionRatio="1:0.6"
-        app:layout_constraintBottom_toTopOf="@id/villainCard"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/heroInfoContainer" />
-
-    <ImageView
-        android:id="@+id/villainCard"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:adjustViewBounds="true"
-        android:background="@drawable/card_background"
-        android:scaleType="centerCrop"
-        app:layout_constraintBottom_toTopOf="@id/continueButton"
-        app:layout_constraintDimensionRatio="3:4"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/runePlaceholder" />
-
-    <Button
-        android:id="@+id/continueButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/continue_to_battle"
-        android:textAllCaps="false"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/villainCard"
-        app:layout_constraintVertical_bias="0" />
-
-</androidx.constraintlayout.widget.ConstraintLayout>
+</FrameLayout>

--- a/app/src/main/res/layout/activity_start_game.xml
+++ b/app/src/main/res/layout/activity_start_game.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -9,61 +10,69 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:contentDescription="@null"
-        android:scaleType="centerCrop"
+        android:scaleType="fitXY"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:src="@drawable/ic_launcher_background" />
+
+    <View
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#99000000"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <View
-        android:id="@+id/selectHeroHotspot"
+    <LinearLayout
+        android:id="@+id/lobbyControls"
         android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:background="@android:color/transparent"
-        android:clickable="true"
-        android:contentDescription="@string/lobby_select_hero"
-        android:focusable="true"
+        android:layout_height="wrap_content"
+        android:layout_margin="24dp"
+        android:background="@drawable/lobby_panel_background"
+        android:orientation="vertical"
+        android:padding="24dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHeight_percent="0.12"
-        app:layout_constraintHorizontal_bias="0.5"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.82"
-        app:layout_constraintWidth_percent="0.4" />
+        app:layout_constraintStart_toStartOf="parent">
 
-    <View
-        android:id="@+id/backHotspot"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:background="@android:color/transparent"
-        android:clickable="true"
-        android:contentDescription="@string/lobby_back"
-        android:focusable="true"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHeight_percent="0.12"
-        app:layout_constraintHorizontal_bias="0.12"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.92"
-        app:layout_constraintWidth_percent="0.26" />
+        <TextView
+            android:id="@+id/selectedHeroLabel"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:text="@string/lobby_select_prompt"
+            android:textColor="@android:color/white"
+            android:textSize="18sp"
+            tools:text="Ήρωας: Mystical Priestess" />
 
-    <View
-        android:id="@+id/startBattleHotspot"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:background="@android:color/transparent"
-        android:clickable="true"
-        android:contentDescription="@string/lobby_start_battle"
-        android:focusable="true"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHeight_percent="0.12"
-        app:layout_constraintHorizontal_bias="0.88"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.92"
-        app:layout_constraintWidth_percent="0.28" />
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/selectHeroButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/lobby_select_hero"
+            android:textAllCaps="false" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/startBattleButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:enabled="false"
+            android:text="@string/lobby_start_battle"
+            android:textAllCaps="false" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/backButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:text="@string/lobby_back"
+            android:textAllCaps="false" />
+
+    </LinearLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="hero_card_corner_radius">16dp</dimen>
+    <dimen name="hero_card_stroke_width">3dp</dimen>
+    <dimen name="hero_card_image_height">220dp</dimen>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,11 +1,11 @@
 <resources>
     <string name="app_name">Rounebound Magic</string>
-    <string name="start_game">Start Game</string>
-    <string name="game_title">Rounebound Magic</string>
-    <string name="start_play">Start Play</string>
     <string name="lobby_select_hero">Επιλογή Ήρωα</string>
-    <string name="lobby_back">Επιστροφή στην εισαγωγή</string>
+    <string name="lobby_select_hero_with_choice">Επιλογή Ήρωα (%1$s)</string>
+    <string name="lobby_selected_hero">Ήρωας: %1$s</string>
+    <string name="lobby_back">Πίσω στην εισαγωγή</string>
     <string name="lobby_start_battle">Έναρξη Μάχης</string>
+    <string name="lobby_select_prompt">Επίλεξε έναν ήρωα πριν ξεκινήσεις</string>
     <string name="select_hero">Επίλεξε τον Ήρωά σου</string>
     <string name="hero_warrior">Warrior</string>
     <string name="hero_mage">Mage</string>
@@ -15,5 +15,9 @@
     <string name="hero_mage_desc">Κυρίαρχος των ρούνων και της μαγείας.</string>
     <string name="hero_priestess_desc">Θεραπεύτρια, σύμμαχος του φωτός.</string>
     <string name="hero_ranger_desc">Τοξότης με υψηλή ευκινησία.</string>
-    <string name="continue_to_battle">Συνέχεια στη μάχη</string>
+    <string name="intro_start_game">Έναρξη Παιχνιδιού</string>
+    <string name="intro_priestess">Η Ιέρεια</string>
+    <string name="intro_black_mage">Ο Μαύρος Μάγος</string>
+    <string name="hero_confirm_selection">Επιβεβαίωση</string>
+    <string name="hero_cancel_selection">Ακύρωση</string>
 </resources>


### PR DESCRIPTION
## Summary
- build a cinematic intro screen that sequences narration audio with rune reveals and hero appearances before enabling the start button
- redesign the lobby to use visible controls, track the selected hero, and hand off the choice to the battle activity
- refresh the hero selection screen with selectable material cards, confirmation controls, and supporting glow/shape resources

## Testing
- ./gradlew lintDebug *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dacc9efb64832883f75f333ce04bc5